### PR TITLE
Fix Ollama client initialization

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -7,7 +7,14 @@ class ChatsController < ApplicationController
     messages = [{ "role" => "system", "content" => tree.llm_sustem_prompt.to_s }] + Array(history)
 
     response.headers['Content-Type'] = 'text/event-stream'
-    client = Ollama.new
+    client = Ollama.new(
+      credentials: {
+        address: ENV.fetch('OLLAMA_URL', 'http://localhost:11434')
+      },
+      options: {
+        server_sent_events: true
+      }
+    )
 
     begin
       client.chat(model: tree.llm_model, messages: messages, stream: lambda { |chunk|


### PR DESCRIPTION
## Summary
- fix chat streaming bug by correctly configuring Ollama client

## Testing
- `ruby test/run_tests.rb`