### PR TITLE
Fix chat call argument usage

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -17,10 +17,10 @@ class ChatsController < ApplicationController
     )
 
     begin
-      client.chat(model: tree.llm_model, messages: messages, stream: lambda { |chunk = nil|
+      client.chat({ model: tree.llm_model, messages: messages }) do |chunk = nil, _raw = nil|
         content = chunk&.dig('message', 'content')
         response.stream.write(content.to_s) if content
-      })
+      end
     ensure
       response.stream.close
     end

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -5,9 +5,9 @@ require 'ostruct'
 # Minimal stub simulating the Ollama client used in ChatsController
 class Ollama
   def initialize(credentials:, options: {}); end
-  def chat(model:, messages:, stream: nil)
+  def chat(payload)
     # Simulate the gem calling the stream handler without arguments
-    stream&.call
+    yield
   end
 end
 
@@ -21,7 +21,8 @@ class ChatsController
       credentials: { address: 'http://localhost:11434' },
       options: { server_sent_events: true }
     )
-    client.chat(model: tree.llm_model, messages: messages, stream: lambda { |_chunk = nil| })
+    client.chat({ model: tree.llm_model, messages: messages }) do |_chunk = nil, _raw = nil|
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- fix how chat call arguments are passed
- adapt streaming test stub

## Testing
- `ruby test/run_tests.rb`