### PR TITLE
Prevent chat width expansion on think details

### DIFF
--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -50,6 +50,10 @@
     width: fit-content;
     margin-right: auto;
   }
+  #chat-history details pre {
+    white-space: pre-wrap;
+    margin: 0;
+  }
 </style>
 <script>
   document.addEventListener('DOMContentLoaded', function() {


### PR DESCRIPTION
## Summary
- keep chat column width fixed when expanding LLM thoughts

## Testing
- `ruby test/run_tests.rb`