### PR TITLE
Add chat persistence models

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -4,7 +4,20 @@ class ChatsController < ApplicationController
   def create
     tree = Tree.find(params[:id])
     history = params[:history].is_a?(String) ? JSON.parse(params[:history]) : params[:history]
-    messages = [{ "role" => "system", "content" => tree.llm_sustem_prompt.to_s }] + Array(history)
+
+    chat = if params[:chat_id].present?
+      Chat.find(params[:chat_id])
+    else
+      Chat.create!(user: @current_user, tree: tree).tap do |c|
+        response.headers['X-Chat-Id'] = c.id.to_s
+      end
+    end
+
+    Array(history).each do |msg|
+      chat.messages.create!(role: msg['role'], content: msg['content'])
+    end
+
+    messages = [{ 'role' => 'system', 'content' => tree.llm_sustem_prompt.to_s }] + Array(history)
 
     response.headers['Content-Type'] = 'text/event-stream'
     client = Ollama.new(
@@ -16,12 +29,18 @@ class ChatsController < ApplicationController
       }
     )
 
+    assistant_content = ''
+
     begin
       client.chat({ model: tree.llm_model, messages: messages }) do |chunk = nil, _raw = nil|
         content = chunk&.dig('message', 'content')
-        response.stream.write(content.to_s) if content
+        if content
+          assistant_content << content
+          response.stream.write(content)
+        end
       end
     ensure
+      chat.messages.create!(role: 'assistant', content: assistant_content)
       response.stream.close
     end
   end

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,0 +1,5 @@
+class Chat < ApplicationRecord
+  belongs_to :user
+  belongs_to :tree
+  has_many :messages, dependent: :destroy
+end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,3 @@
+class Message < ApplicationRecord
+  belongs_to :chat
+end

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -68,6 +68,7 @@
     var markers = [];
     var currentTreeId = null;
     var chatHistory = [];
+    var currentChatId = null;
     trees.forEach(function(tree, idx) {
       if (tree.treedb_lat && tree.treedb_long) {
         var m = L.marker([tree.treedb_lat, tree.treedb_long]).addTo(map).bindPopup(tree.name);
@@ -95,6 +96,7 @@
       document.getElementById('chat-title').textContent = tree.name;
       currentTreeId = tree.id;
       chatHistory = [];
+      currentChatId = null;
       historyDiv.innerHTML = '';
     }
 
@@ -124,8 +126,11 @@
           'Content-Type': 'application/json',
           'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
         },
-        body: JSON.stringify({history: chatHistory})
+        body: JSON.stringify({history: chatHistory, chat_id: currentChatId})
       }).then(function(response){
+        if (!currentChatId) {
+          currentChatId = response.headers.get('X-Chat-Id');
+        }
         var reader = response.body.getReader();
         var decoder = new TextDecoder();
         var botDiv = document.createElement('div');

--- a/db/migrate/20250517152550_create_chats.rb
+++ b/db/migrate/20250517152550_create_chats.rb
@@ -1,0 +1,9 @@
+class CreateChats < ActiveRecord::Migration[7.1]
+  def change
+    create_table :chats do |t|
+      t.references :user, foreign_key: true
+      t.references :tree, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250517152600_create_messages.rb
+++ b/db/migrate/20250517152600_create_messages.rb
@@ -1,0 +1,10 @@
+class CreateMessages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :messages do |t|
+      t.references :chat, foreign_key: true
+      t.string :role
+      t.text :content
+      t.timestamps
+    end
+  end
+end

--- a/test/models/chat_test.rb
+++ b/test/models/chat_test.rb
@@ -1,0 +1,8 @@
+require_relative '../test_helper'
+require 'minitest/autorun'
+
+class ChatTest < Minitest::Test
+  def test_class_defined
+    assert defined?(Chat)
+  end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -1,0 +1,8 @@
+require_relative '../test_helper'
+require 'minitest/autorun'
+
+class MessageTest < Minitest::Test
+  def test_class_defined
+    assert defined?(Message)
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,9 +4,13 @@ Coverage.start
 module ActiveRecord
   class Base
     def self.primary_abstract_class; end
+    def self.belongs_to(*); end
+    def self.has_many(*); end
   end
 end
 
 require_relative '../app/models/application_record'
 require_relative '../app/models/tree'
 require_relative '../app/models/user'
+require_relative '../app/models/chat'
+require_relative '../app/models/message'


### PR DESCRIPTION
## Summary
- add `Chat` and `Message` models
- persist chat history in `ChatsController`
- include chat id on first response and reuse in JS
- provide basic tests for new models

## Testing
- `ruby test/run_tests.rb`