### PR TITLE
Fix seed clearing order

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,6 @@
 # Clear out any existing data so the seed is idempotent
+# Remove associated records in the correct order to avoid foreign key issues
+Chat.destroy_all
 Tree.destroy_all
 User.destroy_all
 


### PR DESCRIPTION
## Summary
- ensure `db:seed` removes `Chat` records before trees and users

## Testing
- `ruby bin/rails test` *(fails: Could not find gem 'rails (~> 7.1)')*