### PR TITLE
Fix db:name_trees for streaming API

### DIFF
--- a/lib/tasks/name_trees.rake
+++ b/lib/tasks/name_trees.rake
@@ -26,7 +26,12 @@ namespace :db do
 
       response = client.chat({ model: 'Qwen3:latest', messages: messages })
       puts "Response: #{response.inspect}"
-      content = response.dig('message', 'content').to_s
+
+      content = if response.is_a?(Array)
+                   response.map { |r| r.dig('message', 'content') }.join
+                 else
+                   response.dig('message', 'content')
+                 end.to_s
       cleaned = content
                 .gsub(/<thinking>.*?<\/thinking>/mi, '')
                 .gsub(/\[.*?\]/m, '')


### PR DESCRIPTION
## Summary
- handle array responses from the ollama client in the `db:name_trees` task

## Testing
- `ruby test/run_tests.rb` *(fails to run rubocop & audits: `bundle: not found`)*