### PR TITLE
Fix name_trees cleanup logic

### DIFF
--- a/lib/tasks/name_trees.rake
+++ b/lib/tasks/name_trees.rake
@@ -33,7 +33,7 @@ namespace :db do
                    response.dig('message', 'content')
                  end.to_s
       cleaned = content
-                .gsub(/<thinking>.*?<\/thinking>/mi, '')
+                .gsub(/<think(?:ing)?>.*?<\/think(?:ing)?>/mi, '')
                 .gsub(/\[.*?\]/m, '')
                 .gsub(/"/, '')
                 .strip


### PR DESCRIPTION
## Summary
- ensure <think> or <thinking> blocks are removed from names
- reload rake task in tests to avoid cross-test interference
- test removal of <think> blocks

## Testing
- `ruby test/run_tests.rb`