### PR TITLE
Fix name cleaning and add tests

### DIFF
--- a/lib/tasks/name_trees.rake
+++ b/lib/tasks/name_trees.rake
@@ -33,7 +33,7 @@ namespace :db do
                    response.dig('message', 'content')
                  end.to_s
       cleaned = content
-                .gsub(/<thinking>.*?<\/thinking>/mi, '')
+                .gsub(/<think(ing)?[^>]*>.*?<\/think(ing)?>/mi, '')
                 .gsub(/\[.*?\]/m, '')
                 .gsub(/"/, '')
                 .strip


### PR DESCRIPTION
## Summary
- handle `<think>` tags in name cleaning
- ensure tasks are loaded in tests even after reinitializing Rake
- test that name cleaning removes think tags

## Testing
- `ruby test/run_tests.rb`