### PR TITLE
Implement naming script TODO

### DIFF
--- a/lib/tasks/name_trees.rake
+++ b/lib/tasks/name_trees.rake
@@ -12,7 +12,7 @@ namespace :db do
       puts "Naming tree #{identifier}"
 
       facts = tree.attributes
-                .except('llm_model', 'llm_sustem_prompt', 'created_at', 'updated_at')
+                .except('id', 'treedb_com_id', 'llm_model', 'llm_sustem_prompt', 'created_at', 'updated_at')
                 .map { |k, v| v.nil? || v.to_s.strip.empty? ? nil : "#{k}: #{v}" }
                 .compact
                 .join("\n")
@@ -25,7 +25,6 @@ namespace :db do
       ]
 
       response = client.chat({ model: 'Qwen3:latest', messages: messages })
-      puts "Response: #{response.inspect}"
 
       content = if response.is_a?(Array)
                    response.map { |r| r.dig('message', 'content') }.join
@@ -42,6 +41,7 @@ namespace :db do
 
       tree.update!(name: cleaned, llm_model: 'Qwen3:latest', llm_sustem_prompt: system_prompt)
       puts "Updated tree #{identifier}"
+      puts
     end
   end
 end

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 ## Todos
 [x] add tailwind and style tree list page
 [x] tree names should be blank when importing
-[ ] naming script should not pass in the treedb id and don't debug the raw response and add a linebreak between trees
+[x] naming script should not pass in the treedb id and don't debug the raw response and add a linebreak between trees
 [ ] naming script verification step1 (< 150chars and > 2 chars)
 [ ] naming script verification step2 (llm approves... prompt the same llm in a new chat to verify the response is a single name)
 [ ] add relationships between trees - neighbors - species - random friends


### PR DESCRIPTION
## Summary
- adjust naming script to skip tree IDs
- remove debug response output
- add blank line between processing each tree
- mark TODO as done in the README

## Testing
- `bundle exec ruby test/run_tests.rb` *(fails: Could not find rails-7.2.2.1, puma-6.6.0, sqlite3-1.7.3-x86_64-linux, ollama-ai-1.3.0, listen-3.9.0, rubocop-1.75)*