### PR TITLE
Add tree neighbor detection

### DIFF
--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -1,2 +1,27 @@
 class Tree < ApplicationRecord
+  EARTH_RADIUS = 6_371_000.0
+
+  def self.haversine_distance(lat1, lon1, lat2, lon2)
+    rad_per_deg = Math::PI / 180
+    dlat_rad = (lat2 - lat1) * rad_per_deg
+    dlon_rad = (lon2 - lon1) * rad_per_deg
+    lat1_rad = lat1 * rad_per_deg
+    lat2_rad = lat2 * rad_per_deg
+
+    a = Math.sin(dlat_rad / 2)**2 +
+        Math.cos(lat1_rad) * Math.cos(lat2_rad) *
+        Math.sin(dlon_rad / 2)**2
+    c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+    EARTH_RADIUS * c
+  end
+
+  def neighbors_within(radius)
+    return [] unless treedb_lat && treedb_long
+
+    self.class.all.to_a.select do |tree|
+      next false if tree == self || tree.treedb_lat.nil? || tree.treedb_long.nil?
+      self.class.haversine_distance(treedb_lat, treedb_long,
+                                    tree.treedb_lat, tree.treedb_long) <= radius
+    end
+  end
 end

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -71,6 +71,27 @@
     var currentTreeId = null;
     var chatHistory = [];
     var currentChatId = null;
+    var radiusCircle = null;
+
+    function distanceMeters(lat1, lon1, lat2, lon2) {
+      var rad = Math.PI / 180;
+      var dLat = (lat2 - lat1) * rad;
+      var dLon = (lon2 - lon1) * rad;
+      var a = Math.sin(dLat/2) * Math.sin(dLat/2) +
+              Math.cos(lat1 * rad) * Math.cos(lat2 * rad) *
+              Math.sin(dLon/2) * Math.sin(dLon/2);
+      var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+      return 6371000 * c;
+    }
+
+    function countNeighbors(tree, radius) {
+      return trees.filter(function(t){
+        if (t === tree) return false;
+        if (!t.treedb_lat || !t.treedb_long) return false;
+        return distanceMeters(tree.treedb_lat, tree.treedb_long,
+                              t.treedb_lat, t.treedb_long) <= radius;
+      }).length;
+    }
 
     function renderBotMessage(div, content) {
       var openIdx = content.indexOf('<think>');
@@ -123,7 +144,23 @@
         markers[index].openPopup();
         map.setView(markers[index].getLatLng(), 17);
       }
-      document.getElementById('chat-title').textContent = tree.name;
+
+      if (radiusCircle) {
+        map.removeLayer(radiusCircle);
+        radiusCircle = null;
+      }
+
+      var neighborCount = countNeighbors(tree, 10);
+      if (tree.treedb_lat && tree.treedb_long) {
+        radiusCircle = L.circle([tree.treedb_lat, tree.treedb_long], {
+          radius: 10,
+          color: '#ff0000',
+          fillOpacity: 0.1
+        }).addTo(map);
+      }
+
+      document.getElementById('chat-title').textContent =
+        tree.name + ' (' + neighborCount + ' neighbors)';
       currentTreeId = tree.id;
       chatHistory = [];
       currentChatId = null;

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] naming script should not pass in the treedb id and don't debug the raw response and add a linebreak between trees
 [x] naming script verification step1 (< 150chars and > 2 chars)
 [x] naming script verification step2 (llm approves... prompt the same llm in a new chat to verify the response is a single name)
-[ ] add a function to find other trees within x meters. When a tree is selected to chat count the trees within 10 meters and show this count next to the tree name in chat like this "Tree Name (<count> neighbors). also create a highlighted radius on the map showing the 10 meters
+[x] add a function to find other trees within x meters. When a tree is selected to chat count the trees within 10 meters and show this count next to the tree name in chat like this "Tree Name (<count> neighbors). also create a highlighted radius on the map showing the 10 meters
 [ ] add rake task to add relationships between trees - neighbors (within 10) - all with same species - 3 random long distance friends
 [ ] trees should be able to tag users and users should be able to tag trees (limited tag list)
 [ ] relationships have tags too

--- a/test/models/tree_test.rb
+++ b/test/models/tree_test.rb
@@ -5,4 +5,22 @@ class TreeTest < Minitest::Test
   def test_class_defined
     assert defined?(Tree)
   end
+
+  def test_neighbors_within_returns_close_trees
+    Tree.singleton_class.class_eval do
+      attr_accessor :records
+      def all; records || []; end
+    end
+
+    t1 = Tree.new(treedb_lat: 0.0, treedb_long: 0.0)
+    t2 = Tree.new(treedb_lat: 0.0, treedb_long: 0.00005) # ~5.5m
+    t3 = Tree.new(treedb_lat: 1.0, treedb_long: 1.0)
+    Tree.records = [t1, t2, t3]
+
+    neighbors = t1.neighbors_within(10)
+    assert_includes neighbors, t2
+    refute_includes neighbors, t3
+  ensure
+    Tree.records = nil
+  end
 end


### PR DESCRIPTION
## Summary
- add `Tree#neighbors_within` with Haversine distance
- show neighbor count when selecting a tree on the map
- highlight selection radius around tree markers
- test neighbor detection logic
- mark todo complete in README

## Testing
- `bundle exec ruby test/run_tests.rb` *(fails: Could not find rails-7.2.2.1 ...)*