### PR TITLE
Fix ApplicationRecord for Rails

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,36 +1,43 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
-  def initialize(attrs = {})
-    @attributes = {}
-    attrs.each do |k, v|
-      send("#{k}=", v)
+  # In the real Rails environment ActiveRecord provides all the attribute
+  # handling we need. For the lightweight test environment we stub only the
+  # minimal behaviour required. Detect this scenario by checking for the
+  # presence of `ActiveRecord::VERSION`, which will only be defined when the
+  # ActiveRecord gem is loaded.
+  unless ActiveRecord.const_defined?(:VERSION)
+    def initialize(attrs = {})
+      @attributes = {}
+      attrs.each do |k, v|
+        send("#{k}=", v)
+      end
     end
-  end
 
-  def attributes
-    (@attributes || {}).transform_keys(&:to_s)
-  end
-
-  def update!(attrs)
-    attrs.each { |k, v| send("#{k}=", v) }
-  end
-
-  def method_missing(name, *args, &block)
-    attr = name.to_s
-    if attr.end_with?('=')
-      (@attributes ||= {})[attr.chomp('=').to_sym] = args.first
-    elsif (@attributes ||= {}).key?(name.to_sym)
-      @attributes[name.to_sym]
-    else
-      super
+    def attributes
+      (@attributes || {}).transform_keys(&:to_s)
     end
-  end
 
-  def respond_to_missing?(name, include_private = false)
-    attr = name.to_s
-    (@attributes ||= {}).key?(name.to_sym) ||
-      (@attributes ||= {}).key?(attr.chomp('=').to_sym) ||
-      super
+    def update!(attrs)
+      attrs.each { |k, v| send("#{k}=", v) }
+    end
+
+    def method_missing(name, *args, &block)
+      attr = name.to_s
+      if attr.end_with?('=')
+        (@attributes ||= {})[attr.chomp('=').to_sym] = args.first
+      elsif (@attributes ||= {}).key?(name.to_sym)
+        @attributes[name.to_sym]
+      else
+        super
+      end
+    end
+
+    def respond_to_missing?(name, include_private = false)
+      attr = name.to_s
+      (@attributes ||= {}).key?(name.to_sym) ||
+        (@attributes ||= {}).key?(attr.chomp('=').to_sym) ||
+        super
+    end
   end
 end


### PR DESCRIPTION
## Summary
- avoid overriding ActiveRecord internals in real Rails
- only stub attribute methods when ActiveRecord is absent

## Testing
- `ruby test/run_tests.rb`