### PR TITLE
Expand neighbor radius & avoid duplicate tree names

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,15 +16,20 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.2'
+      - name: Install dependencies
+        run: bundle install --jobs 4 --retry 3
       - name: Run tests
         run: |
           ruby test/run_tests.rb | tee test_output.txt
+      - name: Run bundler-audit
+        run: |
+          bundle exec bundler-audit check --update | tee bundler_audit_report.txt
       - name: Show reports
         run: |
           echo '### RuboCop' && cat rubocop_report.txt
-          echo '### bundler-audit' && cat bundler_audit_report.txt
           echo '### Brakeman' && cat brakeman_report.txt
           echo '### Coverage' && cat coverage.txt
+          echo '### bundler-audit' && cat bundler_audit_report.txt
       - name: Comment summary
         uses: actions/github-script@v6
         with:

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -150,10 +150,10 @@
         radiusCircle = null;
       }
 
-      var neighborCount = countNeighbors(tree, 10);
+      var neighborCount = countNeighbors(tree, 20);
       if (tree.treedb_lat && tree.treedb_long) {
         radiusCircle = L.circle([tree.treedb_lat, tree.treedb_long], {
-          radius: 10,
+          radius: 20,
           color: '#ff0000',
           fillOpacity: 0.1
         }).addTo(map);

--- a/lib/tasks/name_trees.rake
+++ b/lib/tasks/name_trees.rake
@@ -59,7 +59,19 @@ namespace :db do
                              verify.dig('message', 'content')
                            end.to_s.strip
           if verify_content =~ /^y(es)?/i
-            break
+            neighbor_names = if tree.respond_to?(:treedb_lat) && tree.respond_to?(:treedb_long)
+                               tree.neighbors_within(50)
+                                   .map { |n| n.name.to_s.downcase.strip }
+                                   .reject(&:empty?)
+                             else
+                               []
+                             end
+            if neighbor_names.include?(cleaned.downcase)
+              puts "Rejected duplicate name within 50m: #{cleaned.inspect}"
+              cleaned = nil
+            else
+              break
+            end
           else
             puts "Rejected name after verification: #{cleaned.inspect}"
             cleaned = nil

--- a/lib/tasks/relationships.rake
+++ b/lib/tasks/relationships.rake
@@ -1,7 +1,7 @@
 namespace :db do
   desc 'Add relationships between trees'
   task add_relationships: :environment do
-    radius = 10
+    radius = 20
     trees = Tree.all.to_a
 
     TreeRelationship.delete_all

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,11 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```bash
    ruby test/run_tests.rb
    ```
-6. Start the Rails server:
+6. Run a vulnerability scan with bundler-audit:
+   ```bash
+   bundle exec bundler-audit check --update
+   ```
+7. Start the Rails server:
    ```bash
    bundle exec rails server
    ```
@@ -43,9 +47,10 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] naming script should not pass in the treedb id and don't debug the raw response and add a linebreak between trees
 [x] naming script verification step1 (< 150chars and > 2 chars)
 [x] naming script verification step2 (llm approves... prompt the same llm in a new chat to verify the response is a single name)
-[x] add a function to find other trees within x meters. When a tree is selected to chat count the trees within 10 meters and show this count next to the tree name in chat like this "Tree Name (<count> neighbors). also create a highlighted radius on the map showing the 10 meters
-[x] add rake task to add relationships between trees - neighbors (within 10) - all with same species - 3 random long distance friends
-[ ] naming script should find trees within 50m and avoid duplicate names
+[x] add a function to find other trees within x meters. When a tree is selected to chat count the trees within 20 meters and show this count next to the tree name in chat like this "Tree Name (<count> neighbors). also create a highlighted radius on the map showing the 20 meters
+[x] add rake task to add relationships between trees - neighbors (within 20) - all with same species - 3 random long distance friends
+[x] naming script should find trees within 50m and avoid duplicate names
+[x] integrate bundler-audit and run it in CI
 [ ] all lat/long to User and get from device
 [ ] users should only see a few trees at the start
 [ ] talking to trees should reveal more trees (mostly near, some distant or same species)

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -23,8 +23,6 @@ Minitest.after_run do
   rubocop_output = `bundle exec rubocop 2>&1`
   File.write('rubocop_report.txt', rubocop_output)
 
-  bundler_audit_output = `bundle exec bundler-audit check 2>&1`
-  File.write('bundler_audit_report.txt', bundler_audit_output)
 
   brakeman_output = `bundle exec brakeman -q 2>&1`
   File.write('brakeman_report.txt', brakeman_output)


### PR DESCRIPTION
## Summary
- enlarge neighbor search radius from 10m to 20m
- avoid duplicate names within 50m when naming trees
- adjust rake task for relationships to use 20m
- document completed todo and updated radius
- integrate bundler-audit scan into CI

## Testing
- `ruby test/run_tests.rb`
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec bundler-audit check` *(fails: command not found)*
- `bundle exec brakeman -q` *(fails: command not found)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.