### PR TITLE
Add map location centering

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,12 @@
     </div>
     <div class="flex items-center">
       <span class="mr-2">👤 <%= @current_user&.name %></span>
-      <span class="mr-2">📍 <%= @current_user&.lat && @current_user&.long ? "#{@current_user.lat.round(5)}, #{@current_user.long.round(5)}" : 'unknown' %></span>
+      <span id="location-info" class="mr-2" data-lat="<%= @current_user&.lat %>" data-long="<%= @current_user&.long %>">
+        <span id="locate-icon" class="cursor-pointer">📍</span>
+        <span id="location-text">
+          <%= @current_user&.lat && @current_user&.long ? "#{@current_user.lat.round(5)}, #{@current_user.long.round(5)}" : 'unknown' %>
+        </span>
+      </span>
       <%= form_with url: select_user_path, method: :post, local: true do %>
         <%= select_tag :user_id,
             options_from_collection_for_select(User.all, :id, :name, @current_user&.id),
@@ -28,6 +33,15 @@
     document.addEventListener('DOMContentLoaded', function() {
       if (navigator.geolocation) {
         navigator.geolocation.getCurrentPosition(function(pos) {
+          var info = document.getElementById('location-info');
+          if (info) {
+            info.dataset.lat = pos.coords.latitude;
+            info.dataset.long = pos.coords.longitude;
+            var txtSpan = info.querySelector('#location-text');
+            if (txtSpan) {
+              txtSpan.textContent = pos.coords.latitude.toFixed(5) + ', ' + pos.coords.longitude.toFixed(5);
+            }
+          }
           fetch('<%= update_location_path %>', {
             method: 'POST',
             headers: {

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -72,6 +72,7 @@
     var chatHistory = [];
     var currentChatId = null;
     var radiusCircle = null;
+    var userCircle = null;
 
     function distanceMeters(lat1, lon1, lat2, lon2) {
       var rad = Math.PI / 180;
@@ -254,6 +255,27 @@
         document.getElementById('chat-submit').click();
       }
     });
+
+    var locateIcon = document.getElementById('locate-icon');
+    var locationInfo = document.getElementById('location-info');
+    if (locateIcon && locationInfo) {
+      locateIcon.addEventListener('click', function() {
+        var lat = parseFloat(locationInfo.dataset.lat);
+        var lon = parseFloat(locationInfo.dataset.long);
+        if (isNaN(lat) || isNaN(lon)) return;
+        map.setView([lat, lon], 17);
+        if (userCircle) {
+          map.removeLayer(userCircle);
+          userCircle = null;
+        } else {
+          userCircle = L.circle([lat, lon], {
+            radius: 20,
+            color: '#00ff00',
+            fillOpacity: 0.1
+          }).addTo(map);
+        }
+      });
+    }
 
     if (trees.length > 0) {
       selectTree(0);


### PR DESCRIPTION
## Summary
- make 📍 icon clickable and expose location data on page
- update geolocation script to keep location text and data in sync
- add logic to center the map on user location and toggle a green radius

## Testing
- `bundle exec ruby test/run_tests.rb` *(fails: Could not find gems)*