### PR TITLE
Complete next todo in readme

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -19,7 +19,8 @@ class ChatsController < ApplicationController
       chat.messages.create!(role: msg['role'], content: msg['content'])
     end
 
-    messages = [{ 'role' => 'system', 'content' => tree.llm_sustem_prompt.to_s }] + history.to_a
+    system_prompt = tree.llm_sustem_prompt.to_s + tree.chat_relationship_prompt.to_s
+    messages = [{ 'role' => 'system', 'content' => system_prompt }] + history.to_a
 
     response.headers['Content-Type'] = 'text/event-stream'
     client = Ollama.new(

--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] naming script should find trees within 50m and avoid duplicate names
 [x] add lat/long to User and get from device. display it in the nav bar
 [x] add relation model between users and the trees they know about. users should only see the closest five trees at the start
-[ ] when a user chats with a tree, the tree should be given knowledge about it's neighbors and friends personal names and should be encouraged to casually mention them by their FULL personal names
+[x] when a user chats with a tree, the tree should be given knowledge about it's neighbors and friends personal names and should be encouraged to casually mention them by their FULL personal names
 [ ] when a tree response contains a personal name of a tree they know it should be in bold green text and the user should now know about the new tree if they did not already know it
 [ ] clicking on the bold green name of a tree in a chat should highlight that tree on the map
 [ ] users should be able to tag trees (limited tag list - good, funny, friendly, unique)


### PR DESCRIPTION
## Summary
- expose tree relationships in chat prompts
- include knowledge about neighbours and friends when chatting
- adjust tests for chats controller
- mark todo as complete in README

## Testing
- `ruby test/run_tests.rb`
- `bundle exec bundler-audit check` *(fails: command not found)*