### PR TITLE
Implement chat name map highlight

### DIFF
--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -156,7 +156,7 @@
 
     function revealNewTrees(ids) {
       map.setView(map.getCenter(), 13);
-      Promise.all(ids.map(function(id){
+      return Promise.all(ids.map(function(id){
         return fetch('/trees/' + id + '.json')
           .then(function(resp){ return resp.json(); });
       })).then(function(newTrees){
@@ -224,6 +224,18 @@
       });
     }
 
+    function highlightTreeById(id) {
+      var index = trees.findIndex(function(t){ return t.id === id; });
+      if (index !== -1) {
+        selectTree(index);
+        return;
+      }
+      revealNewTrees([id]).then(function(){
+        var idx = trees.findIndex(function(t){ return t.id === id; });
+        if (idx !== -1) selectTree(idx);
+      });
+    }
+
     function selectTree(index) {
       var tree = trees[index];
       if (!tree) return;
@@ -283,6 +295,12 @@
     });
     var input = document.getElementById('chat-input');
     var historyDiv = document.getElementById('chat-history');
+    historyDiv.addEventListener('click', function(e){
+      if (e.target.classList.contains('tree-name')) {
+        var id = parseInt(e.target.dataset.treeId);
+        if (!isNaN(id)) { highlightTreeById(id); }
+      }
+    });
     document.getElementById('chat-submit').addEventListener('click', function(){
       var text = input.value.trim();
       if (text === '' || !currentTreeId) return;

--- a/readme.md
+++ b/readme.md
@@ -56,7 +56,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] when a user chats with a tree, the tree should be given knowledge about it's neighbors and friends personal names and should be encouraged to casually mention them by their FULL personal names
 [x] the naming task should skip any trees that already have a name
 [x] when a tree response contains a personal name of a tree they know it should be in bold green text and the user should now know about the new tree if they did not already know it
-[ ] clicking on the bold green name of a tree in a chat should highlight that tree on the map
+[x] clicking on the bold green name of a tree in a chat should highlight that tree on the map
 [ ] in the heading of the chat trees should show their neighbors and friends total counts and the number the user knows (eg "Bark Apple Tree Street (2/5 neighbors - 1/3 friends)"). trees should be given a random number of friends (1-6) in the relationships task
 [ ] users should be able to tag trees (limited tag list - good, funny, friendly, unique, ...)
 [ ] tags a user gives a tree should be shown under its title


### PR DESCRIPTION
## Summary
- clicking bold green tree names in chat now highlights that tree on the map
- return a Promise from `revealNewTrees` to chain highlighting logic
- mark README TODO as done

## Testing
- `ruby test/run_tests.rb`