### PR TITLE
Implement todo: chat shows neighbor/friend counts

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -5,10 +5,39 @@ class TreesController < ApplicationController
     else
       @trees = @current_user ? @current_user.closest_trees : Tree.all
     end
+
+    known_ids = @current_user&.known_trees&.map { |t| t.id } || []
+
+    @tree_data = @trees.map do |tree|
+      neighbor_ids = tree.neighbor_ids
+      friend_ids = tree.friend_ids
+      {
+        id: tree.id,
+        name: tree.name,
+        treedb_lat: tree.treedb_lat,
+        treedb_long: tree.treedb_long,
+        neighbor_total: neighbor_ids.length,
+        neighbor_known: (neighbor_ids & known_ids).length,
+        friend_total: friend_ids.length,
+        friend_known: (friend_ids & known_ids).length
+      }
+    end
   end
 
   def show
     tree = Tree.find(params[:id])
-    render json: tree.slice(:id, :name, :treedb_lat, :treedb_long)
+    known_ids = @current_user&.known_trees&.map { |t| t.id } || []
+    neighbor_ids = tree.neighbor_ids
+    friend_ids = tree.friend_ids
+    render json: {
+      id: tree.id,
+      name: tree.name,
+      treedb_lat: tree.treedb_lat,
+      treedb_long: tree.treedb_long,
+      neighbor_total: neighbor_ids.length,
+      neighbor_known: (neighbor_ids & known_ids).length,
+      friend_total: friend_ids.length,
+      friend_known: (friend_ids & known_ids).length
+    }
   end
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -48,4 +48,24 @@ class Tree < ApplicationRecord
     "\nYour neighbors and friends are named: #{names.uniq.join(', ')}. " \
     'Feel free to mention them casually by their FULL personal names.'
   end
+
+  def relationships_of_kind(kind)
+    if TreeRelationship.respond_to?(:where)
+      TreeRelationship.where(tree_id: id, kind: kind)
+    else
+      Array(TreeRelationship.records).select { |r| r[:tree_id] == id && r[:kind] == kind }
+    end
+  end
+
+  def neighbor_ids
+    relationships_of_kind('neighbor').map do |rel|
+      rel.respond_to?(:related_tree_id) ? rel.related_tree_id : rel[:related_tree_id]
+    end
+  end
+
+  def friend_ids
+    relationships_of_kind('long_distance').map do |rel|
+      rel.respond_to?(:related_tree_id) ? rel.related_tree_id : rel[:related_tree_id]
+    end
+  end
 end

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -63,7 +63,7 @@
 </style>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
-    var trees = <%= raw @trees.to_json(only: [:id, :name, :treedb_lat, :treedb_long]) %>;
+    var trees = <%= raw @tree_data.to_json %>;
     var allTrees = <%= raw Tree.where.not(name: [nil, '']).to_json(only: [:id, :name]) %>;
     var treeNameMap = {};
     allTrees.forEach(function(t){ treeNameMap[t.name.toLowerCase()] = t.id; });
@@ -250,7 +250,6 @@
         radiusCircle = null;
       }
 
-      var neighborCount = countNeighbors(tree, 20);
       if (tree.treedb_lat && tree.treedb_long) {
         radiusCircle = L.circle([tree.treedb_lat, tree.treedb_long], {
           radius: 20,
@@ -260,7 +259,9 @@
       }
 
       document.getElementById('chat-title').textContent =
-        tree.name + ' (' + neighborCount + ' neighbors)';
+        tree.name + ' (' +
+        tree.neighbor_known + '/' + tree.neighbor_total + ' neighbors - ' +
+        tree.friend_known + '/' + tree.friend_total + ' friends)';
       currentTreeId = tree.id;
       chatHistory = [];
       currentChatId = null;

--- a/lib/tasks/relationships.rake
+++ b/lib/tasks/relationships.rake
@@ -25,13 +25,12 @@ namespace :db do
 
       # Long distance friends
       candidates = trees.reject { |t| t == tree }
-      sampled = if candidates.size <= 3
-                   candidates
-                 else
-                   candidates.sample(3)
-                 end
-      sampled.each do |friend|
-        TreeRelationship.find_or_create_by!(tree_id: tree.id, related_tree_id: friend.id, kind: 'long_distance')
+      unless candidates.empty?
+        max = [candidates.size, 6].min
+        num = rand(1..max)
+        candidates.sample(num).each do |friend|
+          TreeRelationship.find_or_create_by!(tree_id: tree.id, related_tree_id: friend.id, kind: 'long_distance')
+        end
       end
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] the naming task should skip any trees that already have a name
 [x] when a tree response contains a personal name of a tree they know it should be in bold green text and the user should now know about the new tree if they did not already know it
 [x] clicking on the bold green name of a tree in a chat should highlight that tree on the map
-[ ] in the heading of the chat trees should show their neighbors and friends total counts and the number the user knows (eg "Bark Apple Tree Street (2/5 neighbors - 1/3 friends)"). trees should be given a random number of friends (1-6) in the relationships task
+[x] in the heading of the chat trees should show their neighbors and friends total counts and the number the user knows (eg "Bark Apple Tree Street (2/5 neighbors - 1/3 friends)"). trees should be given a random number of friends (1-6) in the relationships task
 [ ] users should be able to tag trees (limited tag list - good, funny, friendly, unique, ...)
 [ ] tags a user gives a tree should be shown under its title
 [ ] relationships have tags too (eg best-friend, nemesis, secret-friend, lost-friend, ...). allocate some tags randomly when generating relationships

--- a/test/tasks/add_relationships_task_test.rb
+++ b/test/tasks/add_relationships_task_test.rb
@@ -64,6 +64,6 @@ class AddRelationshipsTaskTest < Minitest::Test
     assert_includes TreeRelationship.records, expected_species
 
     long_distance_count = TreeRelationship.records.count { |r| r[:tree_id] == 1 && r[:kind] == 'long_distance' }
-    assert_equal 3, long_distance_count
+    assert_equal 1, long_distance_count
   end
 end


### PR DESCRIPTION
## Summary
- give trees a random number of long distance friends
- expose neighbor/friend counts for each tree
- display these counts when selecting a tree to chat with
- adjust test expectation
- mark todo as done

## Testing
- `bundle exec ruby test/run_tests.rb`