### PR TITLE
Implement friendly tag refresh

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -20,7 +20,8 @@ class TreesController < ApplicationController
         neighbor_known: (neighbor_ids & known_ids).length,
         friend_total: friend_ids.length,
         friend_known: (friend_ids & known_ids).length,
-        tags: tree.tags_for_user(@current_user)
+        tags: tree.tags_for_user(@current_user),
+        user_tags: @current_user.tags_for_tree(tree)
       }
     end
   end
@@ -39,7 +40,8 @@ class TreesController < ApplicationController
       neighbor_known: (neighbor_ids & known_ids).length,
       friend_total: friend_ids.length,
       friend_known: (friend_ids & known_ids).length,
-      tags: tree.tags_for_user(@current_user)
+      tags: tree.tags_for_user(@current_user),
+      user_tags: @current_user.tags_for_tree(tree)
     }
   end
 
@@ -58,6 +60,9 @@ class TreesController < ApplicationController
     if UserTag::ALLOWED_TAGS.include?(tag)
       UserTag.find_or_create_by!(tree: tree, user: @current_user, tag: tag)
     end
-    render json: { tags: @current_user.tags_from_trees }
+    render json: {
+      tags: @current_user.tags_from_trees,
+      user_tags: @current_user.tags_for_tree(tree)
+    }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,19 @@ class User < ApplicationRecord
     end
   end
 
+  def tags_for_tree(tree)
+    return [] unless tree && respond_to?(:id)
+
+    scope = if UserTag.respond_to?(:where)
+              UserTag.where(tree_id: tree.id, user_id: id)
+            else
+              Array(UserTag.records).select do |t|
+                t[:tree_id] == tree.id && t[:user_id] == id
+              end
+            end
+    scope.map { |t| t.respond_to?(:tag) ? t.tag : t[:tag] }
+  end
+
   def chat_tags_prompt
     tags = tags_from_trees.uniq
     return '' if tags.empty?

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -72,6 +72,10 @@
     font-weight: bold;
     color: #006400;
   }
+  #chat-history .locked-thoughts {
+    color: #888;
+    font-style: italic;
+  }
 </style>
 <script>
   document.addEventListener('DOMContentLoaded', function() {
@@ -209,6 +213,9 @@
           body: JSON.stringify({ tag: tag })
         }).then(function(resp){ return resp.json(); }).then(function(data){
           renderUserTags(data.tags || []);
+          var tree = trees.find(function(t){ return t.id === currentTreeId; });
+          if (tree) { tree.user_tags = data.user_tags || tree.user_tags || []; }
+          reRenderBotMessages();
         });
       }
       userTagRegex.lastIndex = 0;
@@ -268,26 +275,52 @@
             markers[idx] = null;
           }
           tree.tags = tree.tags || [];
+          tree.user_tags = tree.user_tags || [];
         });
       });
     }
 
-    function renderBotMessage(div, content) {
-      var openIdx = content.indexOf('<think>');
-      if (openIdx === -1) {
-        div.innerHTML = highlightContent(content);
-        return;
+      function renderBotMessage(div, content) {
+        var openIdx = content.indexOf('<think>');
+        if (openIdx === -1) {
+          div.innerHTML = highlightContent(content);
+          return;
+        }
+        var closeIdx = content.indexOf('</think>', openIdx + 7);
+        var before = content.slice(0, openIdx);
+        var think = closeIdx === -1 ? content.slice(openIdx + 7) : content.slice(openIdx + 7, closeIdx);
+        var after = closeIdx === -1 ? '' : content.slice(closeIdx + 8);
+        var html = '';
+        if (before) html += highlightContent(before);
+        var tree = trees.find(function(t){ return t.id === currentTreeId; });
+        var friendly = tree && Array.isArray(tree.user_tags) && tree.user_tags.indexOf('friendly') !== -1;
+        if (friendly) {
+          html += '<details><summary>LLM thoughts</summary><pre>' + escapeHtml(think) + '</pre></details>';
+        } else {
+          html += '<div class="locked-thoughts">LLM thoughts (requires friendly tag)</div>';
+        }
+        if (after) html += highlightContent(after);
+        div.innerHTML = html;
       }
-      var closeIdx = content.indexOf('</think>', openIdx + 7);
-      var before = content.slice(0, openIdx);
-      var think = closeIdx === -1 ? content.slice(openIdx + 7) : content.slice(openIdx + 7, closeIdx);
-      var after = closeIdx === -1 ? '' : content.slice(closeIdx + 8);
-      var html = '';
-      if (before) html += highlightContent(before);
-      html += '<details><summary>LLM thoughts</summary><pre>' + escapeHtml(think) + '</pre></details>';
-      if (after) html += highlightContent(after);
-      div.innerHTML = html;
-    }
+
+      function reRenderBotMessages() {
+        chatHistory.forEach(function(msg) {
+          if (msg.role === 'assistant' && msg.div) {
+            renderBotMessage(msg.div, msg.content);
+          }
+        });
+      }
+
+      function refreshCurrentTree() {
+        if (!currentTreeId) return;
+        fetch('/trees/' + currentTreeId + '.json')
+          .then(function(resp){ return resp.json(); })
+          .then(function(data){
+            var tree = trees.find(function(t){ return t.id === currentTreeId; });
+            if (tree) { tree.user_tags = data.user_tags || []; }
+            reRenderBotMessages();
+          });
+      }
     trees.forEach(function(tree, idx) {
       if (tree.treedb_lat && tree.treedb_long) {
         var m = L.marker([tree.treedb_lat, tree.treedb_long]).addTo(map).bindPopup(tree.name);
@@ -343,6 +376,7 @@
         tree.neighbor_known + '/' + tree.neighbor_total + ' neighbors - ' +
         tree.friend_known + '/' + tree.friend_total + ' friends)';
       currentTreeId = tree.id;
+      tree.user_tags = tree.user_tags || [];
       renderTags(tree.tags || []);
       chatHistory = [];
       currentChatId = null;
@@ -362,7 +396,7 @@
             } else {
               div.textContent = msg.content;
             }
-            chatHistory.push(msg);
+            chatHistory.push({ role: msg.role, content: msg.content, div: div });
             historyDiv.appendChild(div);
           });
           historyDiv.scrollTop = historyDiv.scrollHeight;
@@ -399,11 +433,11 @@
       var text = input.value.trim();
       if (text === '' || !currentTreeId) return;
       var userMsg = {role: 'user', content: text};
-      chatHistory.push(userMsg);
       var div = document.createElement('div');
       div.className = 'user-message';
       div.textContent = text;
       historyDiv.appendChild(div);
+      chatHistory.push({ role: 'user', content: text, div: div });
       input.value = '';
       historyDiv.scrollTop = historyDiv.scrollHeight;
 
@@ -413,7 +447,10 @@
           'Content-Type': 'application/json',
           'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]').content
         },
-        body: JSON.stringify({history: chatHistory, chat_id: currentChatId})
+        body: JSON.stringify({
+          history: chatHistory.map(function(m){ return { role: m.role, content: m.content }; }),
+          chat_id: currentChatId
+        })
       }).then(function(response){
         if (!currentChatId) {
           currentChatId = response.headers.get('X-Chat-Id');
@@ -433,9 +470,10 @@
           reader.read().then(function(result){
             if (result.done) {
               var finalText = botContent.replace(/<think>[\s\S]*?<\/think>/, '');
-              chatHistory.push({role: 'assistant', content: finalText.trimStart()});
+              chatHistory.push({ role: 'assistant', content: botContent, div: botDiv });
               recordKnownTrees(finalText);
               recordUserTags(finalText);
+              refreshCurrentTree();
               return;
             }
             var chunkText = decoder.decode(result.value, {stream: true});

--- a/readme.md
+++ b/readme.md
@@ -64,7 +64,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] trees should be able to tag users (helpful, friendly, cheeky, funny, bossy, ...)
 [x] display user tags in the nav bar to the left of their name. trees should be given the users tags as additional context in the first chat with a user, it should be framed as things the tree has heard from other trees
 [x] trees should know more about their neighbors and friends in their context (species, tags, relation types...)
-[ ] trees should not allow their thoughts to be expanded unless they are tagged friendly
+[x] trees should not allow their thoughts to be expanded unless they are tagged friendly
 [ ] trees should have missions/objectives that users can help with... find my enemy, find my lost friend, ... (tree must have relation)
 [ ] new tree mission: find the only... tree of a species, tree planted on x date, ... (must be unique in db)
 [ ] new tree mission: find all the ... trees named bob, trees of a species, trees on x road, trees in x park, ... (must be less than 6 in db)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -5,4 +5,17 @@ class UserTest < Minitest::Test
   def test_class_defined
     assert defined?(User)
   end
+
+  def test_tags_for_tree_returns_user_specific_tags
+    UserTag.singleton_class.class_eval { attr_accessor :records }
+    UserTag.records = [
+      { tree_id: 1, user_id: 2, tag: 'friendly' },
+      { tree_id: 2, user_id: 2, tag: 'helpful' }
+    ]
+    user = User.new(id: 2)
+    tree1 = OpenStruct.new(id: 1)
+    assert_equal ['friendly'], user.tags_for_tree(tree1)
+  ensure
+    UserTag.records = nil
+  end
 end


### PR DESCRIPTION
## Summary
- track user-specific tree tags with `tags_for_tree`
- expose `user_tags` from trees and when tagging users
- re-render bot thoughts without page refresh when a tree tags the user friendly
- store full assistant messages so they can be reprocessed
- test `User#tags_for_tree`

## Testing
- `ruby test/run_tests.rb`