### PR TITLE
Implement next 4 readme todos

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -19,7 +19,7 @@ class ChatsController < ApplicationController
       chat.messages.create!(role: msg['role'], content: msg['content'])
     end
 
-    system_prompt = tree.llm_sustem_prompt.to_s + tree.chat_relationship_prompt.to_s
+    system_prompt = tree.llm_sustem_prompt.to_s
     system_prompt += @current_user.chat_tags_prompt if chat.messages.empty?
     messages = [{ 'role' => 'system', 'content' => system_prompt }] + history.to_a
 

--- a/lib/tasks/system_prompts.rake
+++ b/lib/tasks/system_prompts.rake
@@ -1,0 +1,30 @@
+namespace :db do
+  desc 'Generate unique system prompts for trees using Ollama'
+  task system_prompts: :environment do
+    require 'ollama-ai'
+
+    generator_prompt = 'Write a short system prompt for a playful talking tree NPC. Mention that the tree knows other trees but only reveal their names when asked. Include any relationship info provided and respond only with the prompt.'
+
+    client = Ollama.new(credentials: { address: ENV.fetch('OLLAMA_URL', 'http://localhost:11434') })
+
+    Tree.find_each do |tree|
+      user_content = tree.chat_relationship_prompt.to_s
+      species = tree.respond_to?(:treedb_common_name) ? tree.treedb_common_name.to_s.strip : ''
+      user_content = "Species: #{species}\n#{user_content}".strip
+
+      messages = [
+        { 'role' => 'system', 'content' => generator_prompt },
+        { 'role' => 'user', 'content' => user_content }
+      ]
+
+      response = client.chat({ model: 'Qwen3:0.6b', messages: messages })
+      content = if response.is_a?(Array)
+                   response.map { |r| r.dig('message', 'content') }.join
+                 else
+                   response.dig('message', 'content')
+                 end.to_s
+      cleaned = content.gsub(/<think(ing)?[^>]*>.*?<\/think(ing)?>/mi, '').strip
+      tree.update!(llm_sustem_prompt: cleaned, llm_model: 'Qwen3:latest')
+    end
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,23 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```bash
    bundle exec rake db:import_trees
    ```
-5. Run the test suite:
+   You can limit how many trees are imported by passing a count:
+   ```bash
+   bundle exec rake 'db:import_trees[200]'
+   ```
+5. Name the trees:
+   ```bash
+   bundle exec rake db:name_trees
+   ```
+6. Add tree relationships:
+   ```bash
+   bundle exec rake db:add_relationships
+   ```
+7. Generate system prompts:
+   ```bash
+   bundle exec rake db:system_prompts
+   ```
+8. Run the test suite:
    ```bash
    ruby test/run_tests.rb
    ```
@@ -38,7 +54,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    bundle exec bundler-audit check
    bundle exec brakeman -q
    ```
-6. Start the Rails server:
+9. Start the Rails server:
    ```bash
    bundle exec rails server
    ```
@@ -70,10 +86,10 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] trees should be given the context of the users tags and which trees applied those tags to the user
 [x] the llm naming the trees should be given the reasons for previous rejections failure in it's prompt
 [x] tree names should be more like fantasy character names
-[ ] update import trees job to take an optional parameter to limit the import count.
-[ ] when creating trees the system prompt should be blank. create a script to give trees a system prompt. update readme to specify setting up db: seed -> import trees -> name trees -> add relations -> system prompts
-[ ] tree system prompts should encourage the roleplay of the tree character. should encourage trees to hint at trees they know and only reveal them when asked.
-[ ] move info about tree relations to the tree system prompts
+[x] update import trees job to take an optional parameter to limit the import count.
+[x] when creating trees the system prompt should be blank. create a script to give trees a system prompt. update readme to specify setting up db: seed -> import trees -> name trees -> add relations -> system prompts
+[x] tree system prompts should encourage the roleplay of the tree character. should encourage trees to hint at trees they know and only reveal them when asked.
+[x] move info about tree relations to the tree system prompts
 [ ] users should be able to remove tags they applied to a tree
 [ ] when the user clicks on the neighbors or friends count in the chat title a dropdown with the list of related trees should appear with ones not known by the user in light grey with the text "unknown"
 [ ] make the found-a-new-tree animation size relative to zoom

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -20,12 +20,12 @@ end
 # Minimal version of ChatsController#create focusing on the Ollama call
 class ChatsController
   def create(params)
-    tree = params[:tree] || OpenStruct.new(llm_model: 'model', llm_sustem_prompt: 'prompt', chat_relationship_prompt: '')
+    tree = params[:tree] || OpenStruct.new(llm_model: 'model', llm_sustem_prompt: 'prompt')
     history = params[:history]
     history = JSON.parse(history) if history.is_a?(String)
     history = [history] if history.is_a?(Hash)
 
-    system_prompt = tree.llm_sustem_prompt.to_s + tree.chat_relationship_prompt.to_s
+    system_prompt = tree.llm_sustem_prompt.to_s
     messages = [{ 'role' => 'system', 'content' => system_prompt }] + history.to_a
 
     client = Ollama.new(
@@ -117,12 +117,12 @@ class ChatsControllerTest < Minitest::Test
     assert_equal expected, controller.history(chat)
   end
 
-  def test_create_includes_relationship_prompt
+  def test_create_uses_only_system_prompt
     controller = ChatsController.new
     tree = OpenStruct.new(llm_model: 'model', llm_sustem_prompt: 'base', chat_relationship_prompt: ' extras')
     controller.create(history: { 'role' => 'user', 'content' => 'hi' }, tree: tree)
     messages = Ollama.last_payload[:messages]
-    assert_equal 'base extras', messages.first['content']
+    assert_equal 'base', messages.first['content']
   end
 
   def test_maybe_mark_friendly_adds_tag_after_three_messages

--- a/test/tasks/import_trees_task_test.rb
+++ b/test/tasks/import_trees_task_test.rb
@@ -1,0 +1,96 @@
+require_relative '../test_helper'
+require 'rake'
+require 'minitest/autorun'
+require 'stringio'
+require 'uri'
+require 'cgi'
+require 'open-uri'
+require 'active_support/core_ext/object/blank'
+
+class ImportTreesTaskTest < Minitest::Test
+  class << self
+    def setup_tree_class
+      Tree.class_eval do
+        class << self
+          attr_accessor :records
+          def find_or_initialize_by(treedb_com_id:)
+            self.records ||= {}
+            obj = self.records[treedb_com_id] ||= new(
+              name: nil,
+              treedb_com_id: treedb_com_id,
+              treedb_common_name: nil,
+              treedb_genus: nil,
+              treedb_family: nil,
+              treedb_diameter: nil,
+              treedb_date_planted: nil,
+              treedb_age_description: nil,
+              treedb_useful_life_expectency_value: nil,
+              treedb_precinct: nil,
+              treedb_located_in: nil,
+              treedb_uploaddate: nil,
+              treedb_lat: nil,
+              treedb_long: nil,
+              llm_sustem_prompt: nil
+            )
+            obj.define_singleton_method(:new_record?) { true }
+            obj.define_singleton_method(:changed?) { true }
+            obj.define_singleton_method(:save!) { }
+            obj
+          end
+        end
+      end
+    end
+  end
+
+  def setup
+    self.class.setup_tree_class
+    Tree.records = {}
+
+    @responses = {}
+    def stub_response(limit, offset, total)
+      records = (offset...(offset + limit)).map do |i|
+        break if i >= total
+        { 'record' => { 'fields' => { 'com_id' => i.to_s } } }
+      end.compact
+      { 'total_count' => total, 'records' => records }.to_json
+    end
+
+    Rake.application = Rake::Application.new
+    Rake::Task.define_task(:environment)
+    load File.expand_path('../../lib/tasks/import_trees.rake', __dir__)
+  end
+
+  def teardown
+    Tree.records = nil
+  end
+
+  def test_respects_count_parameter
+    total = 3
+    method_ref = method(:stub_response)
+    OpenURI.singleton_class.class_eval do
+      alias_method :orig_open_uri, :open_uri
+      define_method(:open_uri) do |uri, *rest, &block|
+        if uri.to_s.start_with?('http')
+          query = URI.parse(uri.to_s).query
+          params = CGI.parse(query)
+          limit = params['limit'].first.to_i
+          offset = params['offset'].first.to_i
+          io = StringIO.new(method_ref.call(limit, offset, total))
+          block ? block.call(io) : io
+        else
+          orig_open_uri(uri, *rest, &block)
+        end
+      end
+    end
+
+    Rake.application['db:import_trees'].invoke('2')
+
+    assert_equal 2, Tree.records.size
+  ensure
+    OpenURI.singleton_class.class_eval do
+      remove_method :open_uri
+      alias_method :open_uri, :orig_open_uri
+      remove_method :orig_open_uri
+    end
+  end
+end

--- a/test/tasks/system_prompts_task_test.rb
+++ b/test/tasks/system_prompts_task_test.rb
@@ -1,0 +1,92 @@
+require_relative '../test_helper'
+require 'rake'
+require 'minitest/autorun'
+
+class SystemPromptsTaskTest < Minitest::Test
+  class << self
+    def setup_tree_class
+      Tree.class_eval do
+        class << self
+          attr_accessor :instances
+          def find_each
+            (instances || []).each { |t| yield t }
+          end
+        end
+      end
+    end
+
+    attr_accessor :response_data
+  end
+
+  def setup
+    self.class.setup_tree_class
+
+    @tree = Tree.new(name: 'Oak')
+    def @tree.chat_relationship_prompt
+      'rel info'
+    end
+    def @tree.update!(attrs)
+      @prompt = attrs[:llm_sustem_prompt]
+      @model = attrs[:llm_model]
+    end
+    def @tree.prompt; @prompt; end
+    def @tree.model; @model; end
+
+    Tree.instances = [@tree]
+
+    self.class.response_data = { 'message' => { 'content' => 'Generated prompt' } }
+
+    Kernel.module_eval do
+      alias_method :orig_require, :require
+      def require(name)
+        return true if name == 'ollama-ai'
+        orig_require(name)
+      end
+    end
+    @require_patched = true
+
+    @previous_ollama = Object.const_get(:Ollama) if Object.const_defined?(:Ollama)
+    Object.send(:remove_const, :Ollama) if Object.const_defined?(:Ollama)
+
+    stub_ollama = Class.new do
+      class << self
+        attr_accessor :call_count, :last_params
+      end
+
+      def initialize(credentials:); end
+
+      def chat(payload)
+        self.class.call_count = (self.class.call_count || 0) + 1
+        self.class.last_params = payload
+        SystemPromptsTaskTest.response_data
+      end
+    end
+    Object.const_set(:Ollama, stub_ollama)
+    Ollama.call_count = 0
+
+    Rake.application = Rake::Application.new
+    Rake::Task.define_task(:environment)
+    load File.expand_path('../../lib/tasks/system_prompts.rake', __dir__)
+  end
+
+  def teardown
+    Object.send(:remove_const, :Ollama)
+    Object.const_set(:Ollama, @previous_ollama) if @previous_ollama
+    if @require_patched
+      Kernel.module_eval do
+        alias_method :require, :orig_require
+        remove_method :orig_require
+      end
+    end
+    Tree.instances = nil
+  end
+
+  def test_sets_system_prompt
+    Rake.application['db:system_prompts'].invoke
+    assert_equal 'Generated prompt', @tree.prompt
+    assert_equal 'Qwen3:latest', @tree.model
+    params = Ollama.last_params
+    assert_equal 'Qwen3:0.6b', params[:model]
+    assert_includes params[:messages].last['content'], 'rel info'
+  end
+end


### PR DESCRIPTION
## Summary
- allow limiting imported tree count
- use only system prompt when chatting
- add system prompts rake task
- update setup steps
- test system prompt and import rake tasks
- generate system prompts via Ollama

## Testing
- `bundle exec ruby test/run_tests.rb`
