### PR TITLE
Add same species counts to chat header

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -11,6 +11,7 @@ class TreesController < ApplicationController
     @tree_data = @trees.map do |tree|
       neighbor_ids = tree.neighbor_ids
       friend_ids = tree.friend_ids
+      species_ids = tree.same_species_ids
       {
         id: tree.id,
         name: tree.name,
@@ -20,6 +21,8 @@ class TreesController < ApplicationController
         neighbor_known: (neighbor_ids & known_ids).length,
         friend_total: friend_ids.length,
         friend_known: (friend_ids & known_ids).length,
+        species_total: species_ids.length,
+        species_known: (species_ids & known_ids).length,
         tag_counts: tree.tag_counts,
         user_tags: tree.tags_for_user(@current_user)
       }
@@ -31,6 +34,7 @@ class TreesController < ApplicationController
     known_ids = @current_user&.known_trees&.map { |t| t.id } || []
     neighbor_ids = tree.neighbor_ids
     friend_ids = tree.friend_ids
+    species_ids = tree.same_species_ids
     render json: {
       id: tree.id,
       name: tree.name,
@@ -40,8 +44,11 @@ class TreesController < ApplicationController
       neighbor_known: (neighbor_ids & known_ids).length,
       friend_total: friend_ids.length,
       friend_known: (friend_ids & known_ids).length,
+      species_total: species_ids.length,
+      species_known: (species_ids & known_ids).length,
       neighbors: neighbor_ids.map { |nid| { id: nid, name: Tree.find(nid).name } },
       friends: friend_ids.map { |fid| { id: fid, name: Tree.find(fid).name } },
+      same_species: species_ids.map { |sid| { id: sid, name: Tree.find(sid).name } },
       tag_counts: tree.tag_counts,
       user_tags: tree.tags_for_user(@current_user)
     }

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -94,6 +94,12 @@ class Tree < ApplicationRecord
     end
   end
 
+  def same_species_ids
+    relationships_of_kind('same_species').map do |rel|
+      rel.respond_to?(:related_tree_id) ? rel.related_tree_id : rel[:related_tree_id]
+    end
+  end
+
   def tags_for_user(user)
     return [] unless user && respond_to?(:id)
     scope = if TreeTag.respond_to?(:where)

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -20,7 +20,8 @@
       <h2 id="chat-title" class="m-0 text-xl">
         <span id="chat-title-name">Chat</span>
         (<span id="neighbor-info" class="hover:underline cursor-pointer"><span id="neighbor-count">0/0</span> neighbors</span> -
-        <span id="friend-info" class="hover:underline cursor-pointer"><span id="friend-count">0/0</span> friends</span>)
+        <span id="friend-info" class="hover:underline cursor-pointer"><span id="friend-count">0/0</span> friends</span> -
+        <span id="species-info" class="hover:underline cursor-pointer"><span id="species-count">0/0</span> same species</span>)
       </h2>
       <div id="relation-dropdown" class="hidden absolute left-0 top-full mt-1 bg-white border rounded shadow p-2 text-sm z-10"></div>
     </div>
@@ -109,10 +110,9 @@
     var chatHistory = [];
     var currentChatId = null;
     var treeTags = document.getElementById('tree-tags');
-    var neighborCountSpan = document.getElementById('neighbor-count');
-    var friendCountSpan = document.getElementById('friend-count');
     var neighborInfo = document.getElementById('neighbor-info');
     var friendInfo = document.getElementById('friend-info');
+    var speciesInfo = document.getElementById('species-info');
     var relationDropdown = document.getElementById('relation-dropdown');
     var backButton = document.getElementById('back-button');
     var lastTreeId = null;
@@ -381,6 +381,7 @@
           tree.user_tags = tree.user_tags || [];
           tree.neighbors = tree.neighbors || [];
           tree.friends = tree.friends || [];
+          tree.same_species = tree.same_species || [];
         });
       });
     }
@@ -429,14 +430,18 @@
               tree.neighbor_known = data.neighbor_known;
               tree.friend_total = data.friend_total;
               tree.friend_known = data.friend_known;
+              tree.species_total = data.species_total;
+              tree.species_known = data.species_known;
               tree.neighbors = data.neighbors || [];
               tree.friends = data.friends || [];
+              tree.same_species = data.same_species || [];
             }
             renderTags(data.tag_counts || {}, data.user_tags || []);
             if (tree) {
               document.getElementById('chat-title-name').textContent = tree.name;
               document.getElementById('neighbor-count').textContent = tree.neighbor_known + '/' + tree.neighbor_total;
               document.getElementById('friend-count').textContent = tree.friend_known + '/' + tree.friend_total;
+              document.getElementById('species-count').textContent = tree.species_known + '/' + tree.species_total;
             }
             reRenderBotMessages();
             showRelationHighlights();
@@ -494,7 +499,8 @@
         if (!currentTreeId) return;
         var tree = trees.find(function(t){ return t.id === currentTreeId; });
         if (!tree) return;
-        var items = kind === 'neighbor' ? (tree.neighbors || []) : (tree.friends || []);
+        var items = kind === 'neighbor' ? (tree.neighbors || []) :
+                    (kind === 'friend' ? (tree.friends || []) : (tree.same_species || []));
         relationDropdown.innerHTML = '';
         items.forEach(function(it){
           var div = document.createElement('div');
@@ -589,6 +595,8 @@
           tree.neighbor_known + '/' + tree.neighbor_total;
         document.getElementById('friend-count').textContent =
           tree.friend_known + '/' + tree.friend_total;
+        document.getElementById('species-count').textContent =
+          tree.species_known + '/' + tree.species_total;
         currentTreeId = tree.id;
         updateBackButton();
         tree.user_tags = tree.user_tags || [];
@@ -674,6 +682,12 @@
       showRelationDropdown('neighbor', neighborInfo);
     });
     neighborInfo.addEventListener('mouseleave', scheduleHideDropdown);
+
+    speciesInfo.addEventListener('mouseenter', function(e){
+      clearTimeout(hideDropdownTimeout);
+      showRelationDropdown('species', speciesInfo);
+    });
+    speciesInfo.addEventListener('mouseleave', scheduleHideDropdown);
 
     friendInfo.addEventListener('mouseenter', function(e){
       clearTimeout(hideDropdownTimeout);

--- a/test/controllers/trees_controller_test.rb
+++ b/test/controllers/trees_controller_test.rb
@@ -9,17 +9,37 @@ class TreesController
       id: tree[:id],
       name: tree[:name],
       treedb_lat: tree[:treedb_lat],
-      treedb_long: tree[:treedb_long]
+      treedb_long: tree[:treedb_long],
+      neighbor_total: tree[:neighbor_total],
+      neighbor_known: tree[:neighbor_known],
+      friend_total: tree[:friend_total],
+      friend_known: tree[:friend_known],
+      species_total: tree[:species_total],
+      species_known: tree[:species_known],
+      neighbors: tree[:neighbors] || [],
+      friends: tree[:friends] || [],
+      same_species: tree[:same_species] || []
     }
   end
 end
 
 class TreesControllerTest < Minitest::Test
   def test_show_returns_tree_data
-    tree = { id: 1, name: 'Oak', treedb_lat: 1.0, treedb_long: 2.0 }
+    tree = {
+      id: 1,
+      name: 'Oak',
+      treedb_lat: 1.0,
+      treedb_long: 2.0,
+      neighbor_total: 0,
+      neighbor_known: 0,
+      friend_total: 0,
+      friend_known: 0,
+      species_total: 0,
+      species_known: 0
+    }
     controller = TreesController.new
     result = controller.show(tree: tree)
-    expected = { id: 1, name: 'Oak', treedb_lat: 1.0, treedb_long: 2.0 }
+    expected = tree.merge(neighbors: [], friends: [], same_species: [])
     assert_equal expected, result
   end
 end

--- a/test/models/tree_test.rb
+++ b/test/models/tree_test.rb
@@ -23,4 +23,24 @@ class TreeTest < Minitest::Test
   ensure
     Tree.records = nil
   end
+
+  def test_same_species_ids_returns_matching_ids
+    TreeRelationship.singleton_class.class_eval do
+      attr_accessor :records
+      def where(tree_id:, kind:)
+        Array(records).select { |r| r[:tree_id] == tree_id && r[:kind] == kind }
+      end
+    end
+
+    tree = Tree.new
+    tree.define_singleton_method(:id) { 1 }
+    TreeRelationship.records = [
+      { tree_id: 1, related_tree_id: 2, kind: 'same_species' },
+      { tree_id: 1, related_tree_id: 3, kind: 'neighbor' }
+    ]
+
+    assert_equal [2], tree.same_species_ids
+  ensure
+    TreeRelationship.records = nil
+  end
 end


### PR DESCRIPTION
## Summary
- display count of trees with matching species in chat header
- expose same species info via TreesController JSON
- support same species dropdown in chat UI
- track same species relations in tree model
- test same_species_ids method and updated controller output
- remove unused count span variables

## Testing
- `bundle exec ruby test/run_tests.rb`