### PR TITLE
Improve naming retry logic

### DIFF
--- a/lib/tasks/name_trees.rake
+++ b/lib/tasks/name_trees.rake
@@ -39,7 +39,7 @@ namespace :db do
       attempt = 0
       cleaned = nil
       reasons = []
-      while attempt < 3
+      loop do
         attempt += 1
 
         user_content = facts.dup


### PR DESCRIPTION
## Summary
- keep requesting tree names until one is accepted
- log rejected names during naming
- update tests for new retry behaviour

## Testing
- `bundle exec ruby test/run_tests.rb`