### PR TITLE
Implement Ollama setup task

### DIFF
--- a/lib/tasks/ollama.rake
+++ b/lib/tasks/ollama.rake
@@ -1,0 +1,20 @@
+namespace :ollama do
+  desc 'Install Ollama and download configured models'
+  task :setup do
+    require 'yaml'
+
+    puts 'Installing Ollama...'
+    system('bash', '-c', 'curl -fsSL https://ollama.ai/install.sh | sh')
+
+    env = ENV['RAILS_ENV'] || 'development'
+    config_path = File.expand_path('../../../config/llm.yml', __FILE__)
+    config = YAML.load_file(config_path, aliases: true)
+    env_config = config[env] || {}
+
+    models = [env_config['naming_model'], env_config['verify_model'], env_config['final_model']].compact.uniq
+    models.each do |model|
+      puts "Pulling #{model}"
+      system('ollama', 'pull', model)
+    end
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -16,33 +16,37 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```bash
    bundle install
    ```
-2. Create and migrate the database:
+2. Install or update Ollama and download the models:
+   ```bash
+   bundle exec rake ollama:setup
+   ```
+3. Create and migrate the database:
    ```bash
    bundle exec rails db:create
    bundle exec rails db:migrate
    ```
-3. Seed initial users:
+4. Seed initial users:
    ```bash
    bundle exec rails db:seed
    ```
-4. Import tree data (clears existing trees):
+5. Import tree data (clears existing trees):
    ```bash
    bundle exec rake db:import_trees
    ```
    The prompts and models used when naming trees are configured in `config/llm.yml`.
-5. Name the trees:
+6. Name the trees:
    ```bash
    bundle exec rake db:name_trees
    ```
-6. Add tree relationships:
+7. Add tree relationships:
    ```bash
    bundle exec rake db:add_relationships
    ```
-7. Generate system prompts:
+8. Generate system prompts:
    ```bash
    bundle exec rake db:system_prompts
    ```
-8. Run the test suite:
+9. Run the test suite:
    ```bash
    ruby test/run_tests.rb
    ```
@@ -51,7 +55,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    bundle exec bundler-audit check
    bundle exec brakeman -q
    ```
-9. Start the Rails server:
+10. Start the Rails server:
    ```bash
    bundle exec rails server
    ```
@@ -99,7 +103,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
 [x] when a user is chatting with a tree, and that tree has revealed neighbors and friends, those neighbors and friends should have a green ring highlighting them on the map. there should also be a green line connecting the current tree with the revealed neighbors and friends.
 [x] the line connecting the trees should be labeled with the relation type and have a color based on the relation type
 [x] move naming and checking prompts and llm models to a config file
-[ ] create task to setup ollama and download configured models
+[x] create task to setup ollama and download configured models
 [ ] cleanup punctuation in tree names
 [ ] add brakeman report to github action as another new comment
 [ ] address brakeman issues

--- a/test/tasks/ollama_setup_task_test.rb
+++ b/test/tasks/ollama_setup_task_test.rb
@@ -1,0 +1,64 @@
+require_relative '../test_helper'
+require 'rake'
+require 'minitest/autorun'
+
+class OllamaSetupTaskTest < Minitest::Test
+  class << self
+    attr_accessor :system_calls
+  end
+
+  def setup
+    self.class.system_calls = []
+
+    Kernel.module_eval do
+      alias_method :orig_system, :system
+      def system(*args)
+        OllamaSetupTaskTest.system_calls << args
+        true
+      end
+    end
+    @system_patched = true
+
+    YAML.singleton_class.class_eval do
+      alias_method :orig_load_file, :load_file
+      def load_file(_path, **_opts)
+        { 'development' => {
+            'naming_model' => 'model1',
+            'verify_model' => 'model1',
+            'final_model' => 'model2'
+        } }
+      end
+    end
+    @yaml_patched = true
+
+    Rake.application = Rake::Application.new
+    Rake::Task.define_task(:environment)
+    load File.expand_path('../../lib/tasks/ollama.rake', __dir__)
+  end
+
+  def teardown
+    if @system_patched
+      Kernel.module_eval do
+        alias_method :system, :orig_system
+        remove_method :orig_system
+      end
+    end
+
+    if @yaml_patched
+      YAML.singleton_class.class_eval do
+        remove_method :load_file
+        alias_method :load_file, :orig_load_file
+        remove_method :orig_load_file
+      end
+    end
+  end
+
+  def test_pulls_unique_models
+    Rake.application['ollama:setup'].invoke
+
+    assert_includes self.class.system_calls, ['bash', '-c', 'curl -fsSL https://ollama.ai/install.sh | sh']
+    assert_includes self.class.system_calls, ['ollama', 'pull', 'model1']
+    assert_includes self.class.system_calls, ['ollama', 'pull', 'model2']
+    assert_equal 3, self.class.system_calls.length
+  end
+end


### PR DESCRIPTION
## Summary
- create a rake task to download Ollama models
- insert new step in README for setting up models
- mark todo as complete
- test the Ollama setup rake task
- install Ollama before pulling models

## Testing
- `bundle exec ruby test/run_tests.rb`
