### PR TITLE
Fix rubocop documentation warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Base controller providing common helpers and callbacks for the
+# application's controllers.
 class ApplicationController < ActionController::Base
   before_action :set_current_user
 

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Handles chat interactions between users and trees using server sent events.
 class ChatsController < ApplicationController
   include ActionController::Live
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Controller for the landing page.
 class HomeController < ApplicationController
   def index; end
 end

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Provides endpoints for listing and interacting with trees.
 class TreesController < ApplicationController
   def index
     @trees = if @current_user&.user_trees&.any?

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Base class for all ActiveRecord models in the application.
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 

--- a/app/models/chat.rb
+++ b/app/models/chat.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Stores chat sessions between a user and a tree.
 class Chat < ApplicationRecord
   belongs_to :user
   belongs_to :tree

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Individual message within a chat conversation.
 class Message < ApplicationRecord
   belongs_to :chat
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Represents a tree and provides helper methods for relationships and
+# distance calculations.
 class Tree < ApplicationRecord
   EARTH_RADIUS = 6_371_000.0
 

--- a/app/models/tree_relationship.rb
+++ b/app/models/tree_relationship.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Join model connecting trees with relationship metadata.
 class TreeRelationship < ApplicationRecord
   belongs_to :tree
   belongs_to :related_tree, class_name: 'Tree'

--- a/app/models/tree_tag.rb
+++ b/app/models/tree_tag.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Tag applied by a user to a tree.
 class TreeTag < ApplicationRecord
   belongs_to :user
   belongs_to :tree

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Application user with associations to trees and tags.
 class User < ApplicationRecord
   has_many :user_trees, dependent: :destroy
   has_many :known_trees, through: :user_trees, source: :tree

--- a/app/models/user_tag.rb
+++ b/app/models/user_tag.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Tag applied by a tree to a user.
 class UserTag < ApplicationRecord
   belongs_to :tree
   belongs_to :user

--- a/app/models/user_tree.rb
+++ b/app/models/user_tree.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Join table recording which trees a user knows about.
 class UserTree < ApplicationRecord
   belongs_to :user
   belongs_to :tree

--- a/config/application.rb
+++ b/config/application.rb
@@ -7,6 +7,7 @@ require 'rails/all'
 Bundler.require(*Rails.groups)
 
 module TalingTrees
+  # Main Rails application class.
   class Application < Rails::Application
     config.load_defaults 7.1
   end

--- a/db/migrate/20250517152439_create_users.rb
+++ b/db/migrate/20250517152439_create_users.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the users table.
 class CreateUsers < ActiveRecord::Migration[7.1]
   def change
     create_table :users do |t|

--- a/db/migrate/20250517152511_create_trees.rb
+++ b/db/migrate/20250517152511_create_trees.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the trees table.
 class CreateTrees < ActiveRecord::Migration[7.1]
   def change
     create_table :trees do |t|

--- a/db/migrate/20250517152550_create_chats.rb
+++ b/db/migrate/20250517152550_create_chats.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the chats table.
 class CreateChats < ActiveRecord::Migration[7.1]
   def change
     create_table :chats do |t|

--- a/db/migrate/20250517152600_create_messages.rb
+++ b/db/migrate/20250517152600_create_messages.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the messages table.
 class CreateMessages < ActiveRecord::Migration[7.1]
   def change
     create_table :messages do |t|

--- a/db/migrate/20250517152610_create_tree_relationships.rb
+++ b/db/migrate/20250517152610_create_tree_relationships.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the tree_relationships table.
 class CreateTreeRelationships < ActiveRecord::Migration[7.1]
   def change
     create_table :tree_relationships do |t|

--- a/db/migrate/20250517152620_add_lat_long_to_users.rb
+++ b/db/migrate/20250517152620_add_lat_long_to_users.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to add latitude and longitude to users.
 class AddLatLongToUsers < ActiveRecord::Migration[7.1]
   def change
     add_column :users, :lat, :float

--- a/db/migrate/20250517152630_create_user_trees.rb
+++ b/db/migrate/20250517152630_create_user_trees.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the user_trees join table.
 class CreateUserTrees < ActiveRecord::Migration[7.1]
   def change
     create_table :user_trees do |t|

--- a/db/migrate/20250520100000_create_tree_tags.rb
+++ b/db/migrate/20250520100000_create_tree_tags.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the tree_tags table.
 class CreateTreeTags < ActiveRecord::Migration[7.1]
   def change
     create_table :tree_tags do |t|

--- a/db/migrate/20250520100010_add_tag_to_tree_relationships.rb
+++ b/db/migrate/20250520100010_add_tag_to_tree_relationships.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to add a tag column to tree_relationships.
 class AddTagToTreeRelationships < ActiveRecord::Migration[7.1]
   def change
     add_column :tree_relationships, :tag, :string

--- a/db/migrate/20250520100020_create_user_tags.rb
+++ b/db/migrate/20250520100020_create_user_tags.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Migration to create the user_tags table.
 class CreateUserTags < ActiveRecord::Migration[7.1]
   def change
     create_table :user_tags do |t|


### PR DESCRIPTION
## Summary
- document the base controllers
- add docs for all models
- document Rails application
- add docs for all migrations

## Testing
- `bundle exec rubocop`
- `ruby test/run_tests.rb`