### PR TITLE
Relax rubocop limits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,4 @@
+Layout/LineLength:
+  Max: 130
+Metrics/AbcSize:
+  Max: 25


### PR DESCRIPTION
## Summary
- add Rubocop config to loosen the LineLength and AbcSize rules

## Testing
- `bundle exec ruby test/run_tests.rb`