### PR TITLE
Relax RuboCop limits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  NewCops: enable
+
+Layout/LineLength:
+  Max: 140
+
+Metrics/AbcSize:
+  Max: 20
+
+Metrics/MethodLength:
+  Max: 20
+
+Metrics/CyclomaticComplexity:
+  Max: 10


### PR DESCRIPTION
## Summary
- customize RuboCop limits for line length and complexity

## Testing
- `bundle exec ruby test/run_tests.rb` *(fails: bundler-audit couldn't download ruby-advisory-db)*