### PR TITLE
Relax RuboCop limits

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,14 @@
+AllCops:
+  NewCops: enable
+
+Layout/LineLength:
+  Max: 140
+
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/MethodLength:
+  Max: 50
+
+Metrics/CyclomaticComplexity:
+  Max: 25


### PR DESCRIPTION
## Summary
- customize RuboCop limits for line length and complexity

## Testing
- `bundle exec ruby test/run_tests.rb`
  - ✅ tests pass
  - ❌ `bundler-audit` failed to download advisory DB
