### PR TITLE
Fix easy RuboCop issues

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   NewCops: enable
+  Exclude:
+    - 'db/schema.rb'
 
 Layout/LineLength:
   Max: 140

--- a/lib/import_trees.rb
+++ b/lib/import_trees.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Tasks
+  # Imports tree data from the public Melbourne dataset into Tree records.
   class ImportTrees
     BASE_URL = 'https://data.melbourne.vic.gov.au/api/v2/catalog/datasets/trees-with-species-and-dimensions-urban-forest/records'
     DEFAULT_LIMIT = 100

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -15,7 +15,7 @@ class UserTest < Minitest::Test
       { tree_id: 2, user_id: 2, tag: 'helpful' }
     ]
     user = User.new(id: 2)
-    tree1 = OpenStruct.new(id: 1)
+    tree1 = Struct.new(:id, keyword_init: true).new(id: 1)
     assert_equal ['friendly'], user.tags_for_tree(tree1)
   ensure
     UserTag.records = nil

--- a/test/tasks/import_trees_task_test.rb
+++ b/test/tasks/import_trees_task_test.rb
@@ -38,7 +38,7 @@ class ImportTreesTaskTest < Minitest::Test
             )
             obj.define_singleton_method(:new_record?) { true }
             obj.define_singleton_method(:changed?) { true }
-            obj.define_singleton_method(:save!) {}
+            obj.define_singleton_method(:save!) { nil }
             obj
           end
         end
@@ -51,14 +51,6 @@ class ImportTreesTaskTest < Minitest::Test
     Tree.records = {}
 
     @responses = {}
-    def stub_response(limit, offset, total)
-      records = (offset...(offset + limit)).map do |i|
-        break if i >= total
-
-        { 'record' => { 'fields' => { 'com_id' => i.to_s } } }
-      end.compact
-      { 'total_count' => total, 'records' => records }.to_json
-    end
 
     Rake.application = Rake::Application.new
     Rake::Task.define_task(:environment)
@@ -67,6 +59,15 @@ class ImportTreesTaskTest < Minitest::Test
 
   def teardown
     Tree.records = nil
+  end
+
+  def stub_response(limit, offset, total)
+    records = (offset...(offset + limit)).map do |i|
+      break if i >= total
+
+      { 'record' => { 'fields' => { 'com_id' => i.to_s } } }
+    end.compact
+    { 'total_count' => total, 'records' => records }.to_json
   end
 
   def test_respects_count_parameter

--- a/test/tasks/system_prompts_task_test.rb
+++ b/test/tasks/system_prompts_task_test.rb
@@ -23,16 +23,16 @@ class SystemPromptsTaskTest < Minitest::Test
     self.class.setup_tree_class
 
     @tree = Tree.new(name: 'Oak')
-    def @tree.chat_relationship_prompt
-      'rel info'
-    end
+    class << @tree
+      attr_reader :prompt
 
-    def @tree.update!(attrs)
-      @prompt = attrs[:llm_sustem_prompt]
-    end
+      def chat_relationship_prompt
+        'rel info'
+      end
 
-    def @tree.prompt
-      @prompt
+      def update!(attrs)
+        @prompt = attrs[:llm_sustem_prompt]
+      end
     end
 
     Tree.instances = [@tree]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,7 +7,9 @@ module ActiveRecord
   class Base
     def self.primary_abstract_class; end
     def self.belongs_to(*); end
+    # rubocop:disable Naming/PredicateName
     def self.has_many(*); end
+    # rubocop:enable Naming/PredicateName
   end
 end
 


### PR DESCRIPTION
## Summary
- exclude the Rails schema from RuboCop
- add missing class comment to `Tasks::ImportTrees`

## Testing
- `ruby test/run_tests.rb`
- `bundle exec rubocop -A` *(fails: Metrics/AbcSize and other complex cops)*