### PR TITLE
Fix RuboCop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,6 +22,7 @@ Metrics/CyclomaticComplexity:
 Metrics/BlockLength:
   Exclude:
     - 'test/**/*'
+    - 'db/schema.rb'
 
 Metrics/ClassLength:
   Exclude:

--- a/lib/import_trees.rb
+++ b/lib/import_trees.rb
@@ -6,6 +6,21 @@ module Tasks
     BASE_URL = 'https://data.melbourne.vic.gov.au/api/v2/catalog/datasets/trees-with-species-and-dimensions-urban-forest/records'
     DEFAULT_LIMIT = 100
 
+    FIELD_MAP = {
+      'common_name' => :treedb_common_name,
+      'genus' => :treedb_genus,
+      'family' => :treedb_family,
+      'diameter_breast_height' => :treedb_diameter,
+      'date_planted' => :treedb_date_planted,
+      'age_description' => :treedb_age_description,
+      'useful_life_expectency_value' => :treedb_useful_life_expectency_value,
+      'precinct' => :treedb_precinct,
+      'located_in' => :treedb_located_in,
+      'uploaddate' => :treedb_uploaddate,
+      'latitude' => :treedb_lat,
+      'longitude' => :treedb_long
+    }.freeze
+
     def initialize(count: nil)
       @count = count&.to_i
       @count = nil if @count && @count <= 0
@@ -14,41 +29,19 @@ module Tasks
     def run
       require 'net/http'
       require 'json'
-      limit = DEFAULT_LIMIT
       offset = 0
-      total = nil
       imported = 0
+      total = nil
 
       loop do
-        current_limit = [limit, remaining(imported)].min
-        url = "#{BASE_URL}?#{URI.encode_www_form(limit: current_limit, offset: offset)}"
-        puts "Fetching #{url}"
-        data = Net::HTTP.get(URI(url))
-        json = JSON.parse(data)
+        current_limit = [DEFAULT_LIMIT, remaining(imported)].min
+        json = fetch_records(current_limit, offset)
         total ||= json['total_count'].to_i
         records = json['records'] || []
         break if records.empty?
 
         records.each do |record|
-          fields = record.dig('record', 'fields') || {}
-          tree = Tree.find_or_initialize_by(treedb_com_id: fields['com_id'])
-
-          tree.name = nil if tree.name.blank?
-          tree.treedb_common_name ||= fields['common_name']
-          tree.treedb_genus ||= fields['genus']
-          tree.treedb_family ||= fields['family']
-          tree.treedb_diameter ||= fields['diameter_breast_height']
-          tree.treedb_date_planted ||= fields['date_planted']
-          tree.treedb_age_description ||= fields['age_description']
-          tree.treedb_useful_life_expectency_value ||= fields['useful_life_expectency_value']
-          tree.treedb_precinct ||= fields['precinct']
-          tree.treedb_located_in ||= fields['located_in']
-          tree.treedb_uploaddate ||= fields['uploaddate']
-          tree.treedb_lat ||= fields['latitude']
-          tree.treedb_long ||= fields['longitude']
-
-          tree.llm_sustem_prompt = nil if tree.new_record?
-          tree.save! if tree.changed?
+          import_record(record.dig('record', 'fields') || {})
           imported += 1
           break if stop?(imported)
         end
@@ -60,6 +53,29 @@ module Tasks
     end
 
     private
+
+    def fetch_records(limit, offset)
+      url = "#{BASE_URL}?#{URI.encode_www_form(limit: limit, offset: offset)}"
+      puts "Fetching #{url}"
+      data = Net::HTTP.get(URI(url))
+      JSON.parse(data)
+    end
+
+    def import_record(fields)
+      tree = Tree.find_or_initialize_by(treedb_com_id: fields['com_id'])
+      tree.name = nil if tree.name.blank?
+
+      FIELD_MAP.each do |source, attr|
+        value = fields[source]
+        next if value.nil? || value.to_s.strip.empty?
+
+        current = tree.public_send(attr)
+        tree.public_send("#{attr}=", value) if current.blank?
+      end
+
+      tree.llm_sustem_prompt = nil if tree.new_record?
+      tree.save! if tree.changed?
+    end
 
     def remaining(imported)
       return DEFAULT_LIMIT unless @count

--- a/lib/name_trees.rb
+++ b/lib/name_trees.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'tree_namer'
+
 module Tasks
   # Generates names for trees using large language models.
   class NameTrees
@@ -7,127 +9,19 @@ module Tasks
       require 'ollama-ai'
       require 'yaml'
 
+      config = load_config
+      client = Ollama.new(credentials: { address: ENV.fetch('OLLAMA_URL', 'http://localhost:11434') })
+      namer = TreeNamer.new(client, config)
+
+      Tree.find_each { |tree| namer.name_tree(tree) }
+    end
+
+    private
+
+    def load_config
       env = ENV['RAILS_ENV'] || 'development'
       config_path = File.expand_path('../config/llm.yml', __dir__)
-      llm_config = YAML.load_file(config_path, aliases: true)[env]
-
-      system_prompt = llm_config['naming_prompt']
-      verify_prompt_template = llm_config['verify_prompt_template']
-      naming_model = llm_config['naming_model']
-      verify_model = llm_config['verify_model']
-      final_model = llm_config['final_model']
-
-      client = Ollama.new(credentials: { address: ENV.fetch('OLLAMA_URL', 'http://localhost:11434') })
-
-      Tree.find_each do |tree|
-        name_val = if tree.respond_to?(:attributes)
-                     tree.attributes['name']
-                   elsif tree.respond_to?(:name)
-                     tree.name
-                   end
-        next if name_val && !name_val.to_s.strip.empty?
-
-        identifier = tree.respond_to?(:id) ? "##{tree.id}" : tree.to_s
-        puts "Naming tree #{identifier}"
-
-        facts = tree.attributes
-                    .except('id', 'treedb_com_id', 'llm_model', 'llm_sustem_prompt', 'created_at', 'updated_at')
-                    .map { |k, v| v.nil? || v.to_s.strip.empty? ? nil : "#{k}: #{v}" }
-                    .compact
-                    .join("\n")
-
-        neighbor_names = if tree.respond_to?(:treedb_lat) && tree.respond_to?(:treedb_long)
-                           tree.neighbors_within(50).map { |n| n.name.to_s.strip }
-                               .reject(&:empty?)
-                         else
-                           []
-                         end
-        facts += "\nNearby tree names to avoid: #{neighbor_names.join(', ')}" unless neighbor_names.empty?
-
-        puts "Facts:\n#{facts}"
-
-        attempt = 0
-        cleaned = nil
-        reasons = []
-        loop do
-          attempt += 1
-
-          user_content = facts.dup
-          user_content += "\nPrevious failures: #{reasons.join('; ')}" if reasons.any?
-
-          messages = [
-            { 'role' => 'system', 'content' => system_prompt },
-            { 'role' => 'user', 'content' => user_content }
-          ]
-
-          response = client.chat({ model: naming_model, messages: messages })
-
-          content = if response.is_a?(Array)
-                      response.map { |r| r.dig('message', 'content') }.join
-                    else
-                      response.dig('message', 'content')
-                    end.to_s
-          cleaned = content
-                    .gsub(%r{<think(ing)?[^>]*>.*?</think(ing)?>}mi, '')
-                    .gsub(/\[.*?\]/m, '')
-                    .gsub('"', '')
-                    .strip
-
-          if cleaned =~ /[^\w\s,-]/
-            puts "Rejected name due to punctuation: #{cleaned.inspect}"
-            reasons << 'invalid punctuation'
-          elsif cleaned.length > 150 || cleaned.length < 3
-            puts "Rejected name due to length: #{cleaned.inspect}"
-            reasons << 'name too long or short'
-          else
-            verify_prompt = format(
-              verify_prompt_template,
-              common_name: tree.respond_to?(:treedb_common_name) ? tree.treedb_common_name.to_s : '',
-              genus: tree.respond_to?(:treedb_genus) ? tree.treedb_genus.to_s : '',
-              family: tree.respond_to?(:treedb_family) ? tree.treedb_family.to_s : ''
-            )
-            verify_messages = [
-              { 'role' => 'system', 'content' => verify_prompt },
-              { 'role' => 'user', 'content' => cleaned }
-            ]
-            verify = client.chat({ model: verify_model, messages: verify_messages })
-            verify_content = if verify.is_a?(Array)
-                               verify.map { |r| r.dig('message', 'content') }.join
-                             else
-                               verify.dig('message', 'content')
-                             end.to_s.strip
-            if verify_content =~ /^y(es)?/i
-              neighbor_names = if tree.respond_to?(:treedb_lat) && tree.respond_to?(:treedb_long)
-                                 tree.neighbors_within(50)
-                                     .map { |n| n.name.to_s.downcase.strip }
-                                     .reject(&:empty?)
-                               else
-                                 []
-                               end
-              break unless neighbor_names.include?(cleaned.downcase)
-
-              puts "Rejected duplicate name within 50m: #{cleaned.inspect}"
-              reasons << 'duplicate within 50m'
-            else
-              puts "Rejected name after verification: #{cleaned.inspect}"
-              reasons << 'failed verification'
-            end
-          end
-          cleaned = nil
-        end
-
-        unless cleaned
-          puts "Failed to generate valid name after #{attempt} attempts"
-          puts
-          next
-        end
-
-        puts "Cleaned name: #{cleaned}"
-
-        tree.update!(name: cleaned, llm_model: final_model, llm_sustem_prompt: system_prompt)
-        puts "Updated tree #{identifier}"
-        puts
-      end
+      YAML.load_file(config_path, aliases: true)[env]
     end
   end
 end

--- a/lib/tree_namer.rb
+++ b/lib/tree_namer.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Tasks
+  # Handles generating names for trees via LLM
+  class TreeNamer
+    def initialize(client, config)
+      @client = client
+      @config = config
+    end
+
+    def name_tree(tree)
+      return unless name_blank?(tree)
+
+      identifier = tree.respond_to?(:id) ? "##{tree.id}" : tree.to_s
+      puts "Naming tree #{identifier}"
+
+      facts = TreeFacts.new(tree).facts
+      puts "Facts:\n#{facts}"
+
+      generator = TreeNameGenerator.new(@client, @config)
+      name = generator.generate(tree, facts)
+      unless name
+        puts 'Failed to generate valid name'
+        puts
+        return
+      end
+
+      puts "Cleaned name: #{name}"
+      tree.update!(name: name, llm_model: @config['final_model'], llm_sustem_prompt: @config['naming_prompt'])
+      puts "Updated tree #{identifier}"
+      puts
+    end
+
+    private
+
+    def name_blank?(tree)
+      val = if tree.respond_to?(:attributes)
+              tree.attributes['name']
+            elsif tree.respond_to?(:name)
+              tree.name
+            end
+      val.to_s.strip.empty?
+    end
+  end
+
+  # Collects relevant facts about a tree
+  class TreeFacts
+    def initialize(tree)
+      @tree = tree
+    end
+
+    def facts
+      base = @tree.attributes
+                  .except('id', 'treedb_com_id', 'llm_model', 'llm_sustem_prompt', 'created_at', 'updated_at')
+                  .map { |k, v| v.nil? || v.to_s.strip.empty? ? nil : "#{k}: #{v}" }
+                  .compact.join("\n")
+      neighbor_names = if @tree.respond_to?(:treedb_lat) && @tree.respond_to?(:treedb_long)
+                         @tree.neighbors_within(50).map { |n| n.name.to_s.strip }.reject(&:empty?)
+                       else
+                         []
+                       end
+      base += "\nNearby tree names to avoid: #{neighbor_names.join(', ')}" unless neighbor_names.empty?
+      base
+    end
+  end
+
+  # Generates and verifies potential names
+  class TreeNameGenerator
+    def initialize(client, config)
+      @client = client
+      @config = config
+    end
+
+    def generate(tree, facts)
+      attempt = 0
+      reasons = []
+      loop do
+        attempt += 1
+        user_content = facts.dup
+        user_content += "\nPrevious failures: #{reasons.join('; ')}" if reasons.any?
+        messages = [
+          { 'role' => 'system', 'content' => @config['naming_prompt'] },
+          { 'role' => 'user', 'content' => user_content }
+        ]
+        response = @client.chat({ model: @config['naming_model'], messages: messages })
+        content = if response.is_a?(Array)
+                    response.map { |r| r.dig('message', 'content') }.join
+                  else
+                    response.dig('message', 'content')
+                  end.to_s
+        name = clean_name(content)
+        next unless valid_format?(name, reasons)
+        break name if verify_name(name, tree, reasons)
+      end
+    end
+
+    private
+
+    def clean_name(content)
+      content.gsub(%r{<think(ing)?[^>]*>.*?</think(ing)?>}mi, '')
+             .gsub(/\[.*?\]/m, '')
+             .gsub('"', '')
+             .strip
+    end
+
+    def valid_format?(name, reasons)
+      if name =~ /[^\w\s,-]/
+        puts "Rejected name due to punctuation: #{name.inspect}"
+        reasons << 'invalid punctuation'
+        false
+      elsif name.length > 150 || name.length < 3
+        puts "Rejected name due to length: #{name.inspect}"
+        reasons << 'name too long or short'
+        false
+      else
+        true
+      end
+    end
+
+    def verify_name(name, tree, reasons)
+      verify_prompt = format(
+        @config['verify_prompt_template'],
+        common_name: tree.respond_to?(:treedb_common_name) ? tree.treedb_common_name.to_s : '',
+        genus: tree.respond_to?(:treedb_genus) ? tree.treedb_genus.to_s : '',
+        family: tree.respond_to?(:treedb_family) ? tree.treedb_family.to_s : ''
+      )
+      verify_messages = [
+        { 'role' => 'system', 'content' => verify_prompt },
+        { 'role' => 'user', 'content' => name }
+      ]
+      verify = @client.chat({ model: @config['verify_model'], messages: verify_messages })
+      verify_content = if verify.is_a?(Array)
+                         verify.map { |r| r.dig('message', 'content') }.join
+                       else
+                         verify.dig('message', 'content')
+                       end.to_s.strip
+      if verify_content =~ /^y(es)?/i
+        return false if duplicate_name?(name, tree, reasons)
+
+        true
+      else
+        puts "Rejected name after verification: #{name.inspect}"
+        reasons << 'failed verification'
+        false
+      end
+    end
+
+    def duplicate_name?(name, tree, reasons)
+      neighbor_names = if tree.respond_to?(:treedb_lat) && tree.respond_to?(:treedb_long)
+                         tree.neighbors_within(50).map { |n| n.name.to_s.downcase.strip }.reject(&:empty?)
+                       else
+                         []
+                       end
+      return false unless neighbor_names.include?(name.downcase)
+
+      puts "Rejected duplicate name within 50m: #{name.inspect}"
+      reasons << 'duplicate within 50m'
+      true
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- refactor ImportTrees with attribute map
- split naming logic into separate TreeNamer classes
- add TreeNamer to handle generation

## Testing
- `bundle exec rubocop -D`
- `bundle exec ruby test/run_tests.rb`
