### PR TITLE
Capitalize tree names post-acceptance

### DIFF
--- a/lib/tree_namer.rb
+++ b/lib/tree_namer.rb
@@ -25,6 +25,8 @@ module Tasks
         return
       end
 
+      name = name.split.map(&:capitalize).join(' ')
+
       puts "Cleaned name: #{name}"
       tree.update!(name: name, llm_model: @config['final_model'], llm_sustem_prompt: @config['naming_prompt'])
       puts "Updated tree #{identifier}"

--- a/test/tasks/name_trees_task_test.rb
+++ b/test/tasks/name_trees_task_test.rb
@@ -110,6 +110,16 @@ class NameTreesTaskTest < Minitest::Test
     assert_equal 'Crimson Cap', @tree.attributes['name']
   end
 
+  def test_capitalizes_name_before_update
+    self.class.response_data = [
+      { 'message' => { 'content' => 'spruce' } },
+      { 'message' => { 'content' => 'YES' } }
+    ]
+    Rake.application['db:name_trees'].reenable
+    Rake.application['db:name_trees'].invoke
+    assert_equal 'Spruce', @tree.attributes['name']
+  end
+
   def test_skips_trees_with_existing_name
     @tree.attributes['name'] = 'Existing'
     Rake.application['db:name_trees'].reenable


### PR DESCRIPTION
## Summary
- capitalize tree names after they've passed the checks
- test that the naming task capitalizes names

## Testing
- `ruby test/run_tests.rb`