### PR TITLE
Fix rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   NewCops: enable
+  Exclude:
+    - 'db/schema.rb'
 
 Layout/LineLength:
   Max: 140

--- a/lib/tree_namer.rb
+++ b/lib/tree_namer.rb
@@ -106,6 +106,7 @@ module Tasks
     end
 
     BANNED_WORDS_REGEX = /\b(tree|forest|grove)\b/i
+    private_constant :BANNED_WORDS_REGEX
 
     def valid_format?(name, tree, reasons)
       if name =~ /[^\w\s,-]/


### PR DESCRIPTION
## Summary
- exclude `db/schema.rb` from RuboCop
- mark `BANNED_WORDS_REGEX` constant as private

## Testing
- `bundle exec rubocop`
- `ruby test/run_tests.rb`
