### PR TITLE
Reject tree names with digits

### DIFF
--- a/lib/tree_namer.rb
+++ b/lib/tree_namer.rb
@@ -117,6 +117,10 @@ module Tasks
         puts "Rejected name due to length: #{name.inspect}"
         reasons << 'name too long or short'
         false
+      elsif name =~ /\d/
+        puts "Rejected name due to digits: #{name.inspect}"
+        reasons << 'contains digits'
+        false
       elsif tree.respond_to?(:treedb_common_name) &&
             tree.treedb_common_name.to_s.strip != '' &&
             name.downcase.include?(tree.treedb_common_name.to_s.downcase)

--- a/test/tasks/name_trees_task_test.rb
+++ b/test/tasks/name_trees_task_test.rb
@@ -208,6 +208,18 @@ class NameTreesTaskTest < Minitest::Test
     assert_equal 3, Ollama.call_count
   end
 
+  def test_retries_when_name_contains_digits
+    self.class.response_data = [
+      { 'message' => { 'content' => 'Root123' } },
+      { 'message' => { 'content' => 'Valid Name' } },
+      { 'message' => { 'content' => 'YES' } }
+    ]
+    Rake.application['db:name_trees'].reenable
+    Rake.application['db:name_trees'].invoke
+    assert_equal 'Valid Name', @tree.attributes['name']
+    assert_equal 3, Ollama.call_count
+  end
+
   def test_retries_when_name_includes_banned_word
     self.class.response_data = [
       { 'message' => { 'content' => 'Happy Tree' } },


### PR DESCRIPTION
## Summary
- validate tree names to ensure they have no digits
- test retry when a name contains digits

## Testing
- `bundle exec ruby test/run_tests.rb`