### PR TITLE
Fix CI workflow to trigger deploy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: ["*"]
+  push:
+    branches: ["main"]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- fix `CI` workflow to run on pushes to main

## Testing
- `bundle exec ruby test/run_tests.rb`
- `bundle exec brakeman -q`
- `bundle exec rubocop`
- `bundle exec bundler-audit check --update` *(fails: couldn't connect to server)*