### PR TITLE
Fix GitHub action push trigger

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,11 @@
 name: Deploy
 
 on:
-  workflow_run:
-    workflows: ["CI"]
-    types:
-      - completed
+  push:
+    branches: ["main"]
 
 jobs:
   deploy:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -25,7 +22,6 @@ jobs:
       - name: Deploy to Render
         env:
           RENDER_API_KEY: ${{ secrets.RENDER_API_KEY }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
         run: |
           #!/usr/bin/env bash
           set -euo pipefail
@@ -57,16 +53,3 @@ jobs:
           render services deploy \
             --service-id "$SERVICE_ID" \
             --branch main
-      - name: Comment deployment
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const pr = process.env.PR_NUMBER;
-            if (pr) {
-              github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: pr,
-                body: 'Deploy triggered on Render'
-              });
-            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: ["*"]
-  push:
-    branches: ["main"]
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- only run the CI workflow on pull requests
- trigger Render deployment directly on pushes to main

## Testing
- `bundle exec ruby test/run_tests.rb`
