### PR TITLE
Fix Render CLI install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,10 @@ jobs:
           node-version: '18'
       - name: Install Render CLI and jq
         run: |
-          npm install -g render-cli
+          curl -L https://github.com/render-oss/cli/releases/download/v2.1.4/cli_2.1.4_linux_amd64.zip -o render.zip
+          unzip render.zip
+          sudo mv cli /usr/local/bin/render
+          render version
           sudo apt-get update && sudo apt-get install -y jq
       - name: Deploy to Render
         env:


### PR DESCRIPTION
## Summary
- use zipped Render CLI instead of npm version

## Testing
- `ruby test/run_tests.rb`
