### PR TITLE
Optimize tag loading

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -3,7 +3,7 @@
 # Provides endpoints for listing and interacting with trees.
 class TreesController < ApplicationController
   def index
-    @trees = select_trees.includes(:tree_relationships)
+    @trees = select_trees.includes(:tree_relationships, :tree_tags)
     known_ids = @current_user&.known_trees&.map(&:id) || []
     @tree_data = @trees.map { |tree| summary_data(tree, known_ids) }
   end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -104,7 +104,9 @@ class Tree < ApplicationRecord
   end
 
   def user_tree_tags(user)
-    if TreeTag.respond_to?(:where)
+    if respond_to?(:tree_tags) && tree_tags.loaded?
+      tree_tags.select { |t| t.user_id == user.id }
+    elsif TreeTag.respond_to?(:where)
       TreeTag.where(tree_id: id, user_id: user.id)
     else
       Array(TreeTag.records).select { |t| t[:tree_id] == id && t[:user_id] == user.id }
@@ -118,7 +120,9 @@ class Tree < ApplicationRecord
   def tag_counts
     return {} unless respond_to?(:id)
 
-    scope = if TreeTag.respond_to?(:where)
+    scope = if respond_to?(:tree_tags) && tree_tags.loaded?
+              tree_tags
+            elsif TreeTag.respond_to?(:where)
               TreeTag.where(tree_id: id)
             else
               Array(TreeTag.records).select { |t| t[:tree_id] == id }


### PR DESCRIPTION
## Summary
- speed up tree listing by eager loading tags
- avoid N+1 queries for user tags and counts by using loaded associations

## Testing
- `bundle exec ruby test/run_tests.rb`