### PR TITLE
Fix SSE string concat bug

### DIFF
--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -84,7 +84,7 @@ class ChatsController < ApplicationController
     Rails.logger.info("[Ollama] Requesting chat for tree #{tree.id} using model #{model}")
     Rails.logger.debug("[Ollama] Messages: #{messages.inspect}")
 
-    assistant_content = ''
+    assistant_content = String.new
     client.chat({ model: model, messages: messages }) do |chunk = nil, _raw = nil|
       content = chunk&.dig('message', 'content')
       next unless content


### PR DESCRIPTION
## Summary
- fix frozen string error when concatenating assistant response chunks
- improve Ollama and ChatsController test doubles
- test streaming content accumulation

## Testing
- `bundle install --local`
- `bundle exec ruby test/run_tests.rb`