### PR TITLE
[FIX] include tree details in system prompt generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This log summarizes notable updates based on commit history and completed TODO i
 - Added logging for system prompt generation
 - Filtered <think> tags from generated system prompts
 
+## 2025-05-31
+- Added tree details to system prompt generation
+- Included tree name in the generated prompt facts
+
 ## 2025-05-27
 - Switched tree name verification to a rating system with configurable threshold
 - Documented the rating scale and updated tests

--- a/lib/system_prompts.rb
+++ b/lib/system_prompts.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'tree_namer'
+
 module Tasks
   # Generates system prompts for trees using an LLM
   class SystemPrompts
@@ -61,14 +63,9 @@ module Tasks
     end
 
     def facts_for(tree)
-      lines = []
-      lines << "Name: #{tree.name}" if tree.respond_to?(:name)
-      if tree.respond_to?(:treedb_common_name) && tree.treedb_common_name.present?
-        lines << "Species: #{tree.treedb_common_name}"
-      end
+      details = TreeFacts.new(tree).facts
       rel_prompt = tree.chat_relationship_prompt.to_s
-      lines << rel_prompt unless rel_prompt.empty?
-      lines.join("\n")
+      [details, rel_prompt].reject { |l| l.to_s.strip.empty? }.join("\n")
     end
   end
 end

--- a/test/tasks/system_prompts_task_test.rb
+++ b/test/tasks/system_prompts_task_test.rb
@@ -24,7 +24,7 @@ class SystemPromptsTaskTest < Minitest::Test
   def setup
     self.class.setup_tree_class
 
-    @tree = Tree.new(name: 'Oak')
+    @tree = Tree.new(name: 'Oak', treedb_common_name: 'Blue Gum')
     class << @tree
       attr_reader :prompt
 
@@ -94,6 +94,7 @@ class SystemPromptsTaskTest < Minitest::Test
     content = self.class.last_params[:messages][1]['content']
     assert_includes content, 'rel info'
     assert_includes content, 'Oak'
+    assert_includes content, 'Blue Gum'
   end
 
   def test_think_tag_removed


### PR DESCRIPTION
## Summary
- include `TreeFacts` in system prompt generator
- ensure prompt generation includes tree attributes and name
- update system prompt task test accordingly
- document the change in `CHANGELOG.md`

## Testing
- `ruby test/run_tests.rb`