### PR TITLE
[FIX] expand duplicate name check radius

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-03
+- Increased duplicate name check radius to 100m
+
 ## 2025-06-02
 - Added validation loop for system prompt generation
 

--- a/lib/tree_namer.rb
+++ b/lib/tree_namer.rb
@@ -57,7 +57,7 @@ module Tasks
                   .map { |k, v| v.nil? || v.to_s.strip.empty? ? nil : "#{k}: #{v}" }
                   .compact.join("\n")
       neighbor_names = if @tree.respond_to?(:treedb_lat) && @tree.respond_to?(:treedb_long)
-                         @tree.neighbors_within(50).map { |n| n.name.to_s.strip }.reject(&:empty?)
+                         @tree.neighbors_within(100).map { |n| n.name.to_s.strip }.reject(&:empty?)
                        else
                          []
                        end
@@ -170,14 +170,14 @@ module Tasks
 
     def duplicate_name?(name, tree, reasons)
       neighbor_names = if tree.respond_to?(:treedb_lat) && tree.respond_to?(:treedb_long)
-                         tree.neighbors_within(50).map { |n| n.name.to_s.downcase.strip }.reject(&:empty?)
+                         tree.neighbors_within(100).map { |n| n.name.to_s.downcase.strip }.reject(&:empty?)
                        else
                          []
                        end
       return false unless neighbor_names.include?(name.downcase)
 
-      puts "Rejected duplicate name within 50m: #{name.inspect}"
-      reasons << 'duplicate within 50m'
+      puts "Rejected duplicate name within 100m: #{name.inspect}"
+      reasons << 'duplicate within 100m'
       true
     end
   end

--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Deployed to Koyeb: https://visiting-raynell-puzzleduck-f206ac43.koyeb.app/
 [x] naming script verification step2 (llm approves... prompt the same llm in a new chat to verify the response is a single name)
 [x] add a function to find other trees within x meters. When a tree is selected to chat count the trees within 20 meters and show this count next to the tree name in chat like this "Tree Name (<count> neighbors). also create a highlighted radius on the map showing the 20 meters
 [x] add rake task to add relationships between trees - neighbors (within 20) - all with same species - 3 random long distance friends
-[x] naming script should find trees within 50m and avoid duplicate names
+[x] naming script should find trees within 100m and avoid duplicate names
 [x] add lat/long to User and get from device. display it in the nav bar
 [x] add relation model between users and the trees they know about. users should only see the closest five trees at the start
 [x] when a user chats with a tree, the tree should be given knowledge about it's neighbors and friends personal names and should be encouraged to casually mention them by their FULL personal names


### PR DESCRIPTION
## Summary
- reject tree names if another tree within 100m uses the same name
- update docs about duplicate name check

## Testing
- `ruby test/run_tests.rb`