### PR TITLE
[FIX] rename llm prompt column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-05
+- Renamed `llm_sustem_prompt` column to `llm_system_prompt`
+
 ## 2025-06-03
 - Increased duplicate name check radius to 100m
 

--- a/app/controllers/chats_controller.rb
+++ b/app/controllers/chats_controller.rb
@@ -67,7 +67,7 @@ class ChatsController < ApplicationController
   end
 
   def build_messages(tree, chat, history)
-    system_prompt = tree.llm_sustem_prompt.to_s
+    system_prompt = tree.llm_system_prompt.to_s
     system_prompt += @current_user.chat_tags_prompt if chat.messages.empty?
     [{ 'role' => 'system', 'content' => system_prompt }] + history.to_a
   end

--- a/db/migrate/20250604000000_rename_llm_sustem_prompt.rb
+++ b/db/migrate/20250604000000_rename_llm_sustem_prompt.rb
@@ -1,0 +1,5 @@
+class RenameLlmSustemPrompt < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :trees, :llm_sustem_prompt, :llm_system_prompt
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,7 +67,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_05_20_100020) do
     t.float "treedb_lat"
     t.float "treedb_long"
     t.string "llm_model"
-    t.text "llm_sustem_prompt"
+    t.text "llm_system_prompt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/lib/import_trees.rb
+++ b/lib/import_trees.rb
@@ -56,7 +56,7 @@ module Tasks
         tree.public_send("#{attr}=", value) if current.blank?
       end
 
-      tree.llm_sustem_prompt = nil if tree.new_record?
+      tree.llm_system_prompt = nil if tree.new_record?
       tree.save! if tree.changed?
     end
 

--- a/lib/system_prompts.rb
+++ b/lib/system_prompts.rb
@@ -15,7 +15,7 @@ module Tasks
 
       Tree.find_each do |tree|
         identifier = tree.respond_to?(:id) ? "##{tree.id}" : tree.to_s
-        next if tree.llm_sustem_prompt.present?
+        next if tree.llm_system_prompt.present?
 
         puts ''
         puts "Generating system prompt for tree #{identifier}"
@@ -23,7 +23,7 @@ module Tasks
         prompt = generator.generate(tree)
         puts "Final prompt:\n#{prompt}"
 
-        tree.update!(llm_sustem_prompt: prompt)
+        tree.update!(llm_system_prompt: prompt)
         puts "Updated tree #{identifier}"
         puts
       end

--- a/lib/tree_namer.rb
+++ b/lib/tree_namer.rb
@@ -53,7 +53,7 @@ module Tasks
 
     def facts
       base = @tree.attributes
-                  .except('id', 'treedb_com_id', 'llm_model', 'llm_sustem_prompt', 'created_at', 'updated_at')
+                 .except('id', 'treedb_com_id', 'llm_model', 'llm_system_prompt', 'created_at', 'updated_at')
                   .map { |k, v| v.nil? || v.to_s.strip.empty? ? nil : "#{k}: #{v}" }
                   .compact.join("\n")
       neighbor_names = if @tree.respond_to?(:treedb_lat) && @tree.respond_to?(:treedb_long)

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -2,7 +2,7 @@
 
 require_relative '../test_helper'
 require 'minitest/autorun'
-TreeStub = Struct.new(:id, :llm_model, :llm_sustem_prompt, :chat_relationship_prompt, keyword_init: true)
+TreeStub = Struct.new(:id, :llm_model, :llm_system_prompt, :chat_relationship_prompt, keyword_init: true)
 MessageStub = Struct.new(:role, :content, keyword_init: true)
 ChatStub = Struct.new(:id, :user, :tree, :messages, keyword_init: true)
 UserStub = Struct.new(:id, keyword_init: true)
@@ -27,12 +27,12 @@ end
 # Minimal version of ChatsController#create focusing on the Ollama call
 class ChatsController
   def create(params)
-    tree = params[:tree] || TreeStub.new(llm_model: 'model', llm_sustem_prompt: 'prompt')
+    tree = params[:tree] || TreeStub.new(llm_model: 'model', llm_system_prompt: 'prompt')
     history = params[:history]
     history = JSON.parse(history) if history.is_a?(String)
     history = [history] if history.is_a?(Hash)
 
-    system_prompt = tree.llm_sustem_prompt.to_s
+    system_prompt = tree.llm_system_prompt.to_s
     messages = [{ 'role' => 'system', 'content' => system_prompt }] + history.to_a
 
     client = Ollama.new(
@@ -149,7 +149,7 @@ class ChatsControllerTest < Minitest::Test
 
   def test_create_uses_only_system_prompt
     controller = ChatsController.new
-    tree = TreeStub.new(llm_model: 'model', llm_sustem_prompt: 'base', chat_relationship_prompt: ' extras')
+    tree = TreeStub.new(llm_model: 'model', llm_system_prompt: 'base', chat_relationship_prompt: ' extras')
     controller.create(history: { 'role' => 'user', 'content' => 'hi' }, tree: tree)
     messages = Ollama.last_payload[:messages]
     assert_equal 'base', messages.first['content']

--- a/test/tasks/import_trees_task_test.rb
+++ b/test/tasks/import_trees_task_test.rb
@@ -31,7 +31,7 @@ class ImportTreesTaskTest < Minitest::Test
               treedb_uploaddate: nil,
               treedb_lat: nil,
               treedb_long: nil,
-              llm_sustem_prompt: nil
+              llm_system_prompt: nil
             )
             obj.define_singleton_method(:new_record?) { true }
             obj.define_singleton_method(:changed?) { true }

--- a/test/tasks/name_trees_task_test.rb
+++ b/test/tasks/name_trees_task_test.rb
@@ -101,7 +101,7 @@ class NameTreesTaskTest < Minitest::Test
 
   def test_does_not_assign_system_prompt
     Rake.application['db:name_trees'].invoke
-    assert_nil @tree.attributes['llm_sustem_prompt']
+    assert_nil @tree.attributes['llm_system_prompt']
   end
 
   def test_response_is_cleaned_of_think_tags

--- a/test/tasks/system_prompts_task_test.rb
+++ b/test/tasks/system_prompts_task_test.rb
@@ -24,7 +24,15 @@ class SystemPromptsTaskTest < Minitest::Test
   def setup
     self.class.setup_tree_class
 
-    @tree = Tree.new(name: 'Oak', treedb_common_name: 'Blue Gum')
+    TreeRelationship.singleton_class.class_eval do
+      attr_accessor :records
+
+      def where(tree_id:, kind: nil)
+        Array(records).select { |r| r.tree_id == tree_id }
+      end
+    end
+
+    @tree = Tree.new(name: 'Oak', treedb_common_name: 'Blue Gum', llm_system_prompt: nil)
     @tree.define_singleton_method(:id) { 1 }
     class << @tree
       attr_reader :prompt
@@ -34,7 +42,7 @@ class SystemPromptsTaskTest < Minitest::Test
       end
 
       def update!(attrs)
-        @prompt = attrs[:llm_sustem_prompt]
+        @prompt = attrs[:llm_system_prompt]
       end
     end
 
@@ -161,7 +169,7 @@ class SystemPromptsTaskTest < Minitest::Test
         Array(records).select { |r| r.tree_id == tree_id }
       end
     end
-    related = Tree.new(name: 'Piny')
+    related = Tree.new(name: 'Piny', llm_system_prompt: nil)
     rel = TreeRelationship.new(tree_id: 1, related_tree: related, kind: 'neighbor')
     TreeRelationship.records = [rel]
 


### PR DESCRIPTION
## Summary
- rename `llm_sustem_prompt` column to `llm_system_prompt`
- adjust schema, migrations, and application code
- update tests and prompt generation logic
- keep the original column name in the initial migration

## Testing
- `ruby test/run_tests.rb`