### PR TITLE
[FIX] compile css in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-06
+- Installed Node dependencies and compiled Tailwind CSS during Docker build
+- Compiled CSS in the entrypoint to ensure styles are available
+
 ## 2025-06-05
 - Renamed `llm_sustem_prompt` column to `llm_system_prompt`
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ ENV PATH=${ASDF_DIR}/bin:${ASDF_DIR}/shims:${PATH}
 RUN git clone https://github.com/asdf-vm/asdf.git ${ASDF_DIR} --branch v0.12.0
 
 WORKDIR /myapp
-COPY .tool-versions Gemfile Gemfile.lock ./
+COPY .tool-versions Gemfile Gemfile.lock package.json yarn.lock ./
 
 RUN bash -lc "\
       . ${ASDF_DIR}/asdf.sh && \
@@ -35,10 +35,12 @@ RUN bash -lc "\
       asdf install && \
       asdf global ruby \$(awk '/^ruby/ {print \$2}' .tool-versions) \
     " && \
-    bash -lc "gem install bundler && bundle install --without development test --jobs 4 --retry 3"
+    bash -lc "gem install bundler && bundle install --without development test --jobs 4 --retry 3" \
+    && yarn install --frozen-lockfile
 
 # copy the rest of your code
 COPY . .
+RUN yarn build:css
 ENV RAILS_ENV=production
 ENV SECRET_KEY_BASE=705bbf912138dbddea76f9a859a37a9f1e966d0d61fdc9f093ded8f4bfa44f0104ebae62022199d31700a8346aa912f39212ca2f7d8e8cc9a3f7600a2eb3375c
 RUN bundle exec rails db:migrate

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,5 +18,8 @@ sleep 5
 # bundle exec rake db:add_relationships
 # bundle exec rake db:system_prompts
 
+# Compile Tailwind CSS
+yarn build:css
+
 # 4) Finally, launch Rails
 exec bundle exec rails server -b 0.0.0.0

--- a/readme.md
+++ b/readme.md
@@ -62,12 +62,11 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```
 
 11. Build css:
-   ```
-   bundle exec rails assets:clobber
-   RAILS_ENV=development bundle exec rails assets:precompile
+   ```bash
+   yarn build:css
    ```
 
-11. Start the Rails server:
+12. Start the Rails server:
    ```bash
    ./bin/dev
    ```


### PR DESCRIPTION
## Summary
- install node dependencies during Docker build
- compile CSS in Dockerfile and entrypoint
- document CSS build step in README

## Testing
- `ruby test/run_tests.rb`