### PR TITLE
[FIX] RuboCop output in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           bundle exec brakeman -q | tee brakeman_report.txt
       - name: Run RuboCop
         run: |
-          bundle exec rubocop | tee rubocop_report.txt
+          bundle exec rubocop --no-color | tee rubocop_report.txt
         continue-on-error: true
       - name: Run bundler-audit
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-07
+- Disabled RuboCop color output so CI comments render correctly
+
 ## 2025-06-06
 - Installed Node dependencies and compiled Tailwind CSS during Docker build
 - Compiled CSS in the entrypoint to ensure styles are available

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -27,7 +27,7 @@ Minitest.after_run do
     f.puts "TOTAL: #{total_percent}% (#{total_covered}/#{total_lines})"
   end
 
-  rubocop_output = `bundle exec rubocop 2>&1`
+  rubocop_output = `bundle exec rubocop --no-color 2>&1`
   File.write('rubocop_report.txt', rubocop_output)
 
   bundler_audit_output = `bundle exec bundler-audit check 2>&1`


### PR DESCRIPTION
## Summary
- prevent ANSI color codes in RuboCop output
- update changelog

## Testing
- `ruby test/run_tests.rb`
- `bundle exec rubocop test/run_tests.rb`