### PR TITLE
[FIX] install yarn via corepack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-08
+- Enabled Yarn 4 via corepack in the Docker build and README instructions
+
 ## 2025-06-07
 - Switched Docker build to use `yarn install --immutable` for compatibility with Yarn 4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get update -qq && \
       git \
       curl \
       nodejs \
-      yarn \
       libpq-dev && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    corepack enable && corepack prepare yarn@stable --activate
 
 # asdf for Ruby 3.2.3 (your .tool-versions)
 ENV ASDF_DIR=/root/.asdf

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,10 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```bash
    bundle install
    ```
-2. Install Node packages:
+2. Install Node packages (requires Yarn 4 via corepack):
    ```bash
+   corepack enable
+   corepack prepare yarn@stable --activate
    yarn install --immutable
    ```
 3. Install or update Ollama and download the models:


### PR DESCRIPTION
## Summary
- use corepack to activate Yarn 4 in Dockerfile
- document corepack usage in setup guide

## Testing
- `ruby test/run_tests.rb`