### PR TITLE
[FIX] handle missing rubocop report

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           bundle exec brakeman -q | tee brakeman_report.txt
       - name: Run RuboCop
         run: |
-          bundle exec rubocop | tee rubocop_report.txt
+          bundle exec rubocop --format simple --no-color | tee rubocop_report.txt
         continue-on-error: true
       - name: Run bundler-audit
         run: |
@@ -61,7 +61,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('rubocop_report.txt','utf8');
+            const path = 'rubocop_report.txt';
+            let report = '';
+            if (fs.existsSync(path)) {
+              report = fs.readFileSync(path, 'utf8');
+            }
             const body = `**RuboCop Report**\n\n\`\`\`\n${report}\n\`\`\``;
             github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This log summarizes notable updates based on commit history and completed TODO i
 ## 2025-06-07
 - Switched Docker build to use `yarn install --immutable` for compatibility with Yarn 4
 
+## 2025-06-08
+- Disabled color output for RuboCop in CI to fix empty report comments
+
+## 2025-06-09
+- Improved CI workflow to read RuboCop report only when the file exists
+
 ## 2025-06-06
 - Installed Node dependencies and compiled Tailwind CSS during Docker build
 - Compiled CSS in the entrypoint to ensure styles are available

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ must configure this value manually.
 [x] address bundler-audit issues
 [x] add rubocop report to github action as another new comment
 [x] address rubocop issues
+[x] fix blank rubocop report in CI comment
 [x] create new github action to trigger deploy to Keyob on merge to master
 [x] review agents-advice.md and create AGENTS.md for project
 [x] get test coverage up to 50%

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -27,7 +27,7 @@ Minitest.after_run do
     f.puts "TOTAL: #{total_percent}% (#{total_covered}/#{total_lines})"
   end
 
-  rubocop_output = `bundle exec rubocop 2>&1`
+  rubocop_output = `bundle exec rubocop --format simple --no-color 2>&1`
   File.write('rubocop_report.txt', rubocop_output)
 
   bundler_audit_output = `bundle exec bundler-audit check 2>&1`


### PR DESCRIPTION
## Summary
- ensure GitHub script checks for `rubocop_report.txt` before reading
- document workflow tweak in CHANGELOG

## Testing
- `bundle exec rubocop --format simple --no-color`
- `bundle exec bundler-audit check --update` *(fails: couldn't connect to server)*
- `bundle exec brakeman -q`
- `bundle exec ruby test/run_tests.rb`
