### PR TITLE
[FIX] use Yarn 1 lockfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This log summarizes notable updates based on commit history and completed TODO i
 - Documented Node.js requirement in README
 - Enabled Yarn 4 via corepack in the Docker build and README instructions
 
+## 2025-06-10
+- Reverted to Yarn 1 to avoid lockfile modifications during Docker builds
+- Updated Dockerfile and README accordingly
+
 ## 2025-06-07
 - Switched Docker build to use `yarn install --immutable` for compatibility with Yarn 4
 - Updated controller tests to exercise real application code

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qq && \
     curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/* && \
-    corepack enable && corepack prepare yarn@stable --activate
+    corepack enable && corepack prepare yarn@1.22.19 --activate
 
 # asdf for Ruby 3.2.3 (your .tool-versions)
 ENV ASDF_DIR=/root/.asdf
@@ -37,7 +37,7 @@ RUN bash -lc "\
       asdf global ruby \$(awk '/^ruby/ {print \$2}' .tool-versions) \
     " && \
     bash -lc "gem install bundler && bundle install --without development test --jobs 4 --retry 3" \
-    && yarn install --immutable
+    && yarn install --frozen-lockfile
 
 # copy the rest of your code
 COPY . .

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "app",
   "private": "true",
+  "packageManager": "yarn@1.22.19",
   "dependencies": {
     "@tailwindcss/cli": "^4.1.7",
     "tailwindcss": "^4.1.7"

--- a/readme.md
+++ b/readme.md
@@ -21,11 +21,11 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
    sudo apt-get install -y nodejs
    ```
-3. Install Node packages (requires Yarn 4 via corepack):
+3. Install Node packages (requires Yarn 1 via corepack):
    ```bash
    corepack enable
-   corepack prepare yarn@stable --activate
-   yarn install --immutable
+   corepack prepare yarn@1.22.19 --activate
+   yarn install --frozen-lockfile
    ```
 4. Install or update Ollama and download the models:
    ```bash


### PR DESCRIPTION
## Summary
- lock Yarn version to v1 in package.json
- update README instructions for Yarn 1
- use Yarn 1 during Docker build and install with frozen lockfile
- log the change in CHANGELOG

## Testing
- `ruby test/run_tests.rb`
- `bundle exec rubocop`
- `bundle exec bundler-audit check`
- `bundle exec brakeman -q`
