### PR TITLE
FEATURE add rake task for vic suburbs dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This log summarizes notable updates based on commit history and completed TODO i
 - Simplified CI workflow to rely on `test/run_tests.rb` for security and linting reports
 - Added workflow to build Docker image in CI
 
+## 2025-05-26
+- Added rake task `db:download_vic_suburbs` to download Victorian suburb shapefiles
+
 ## 2025-06-09
 - Installed Node.js 20 via NodeSource in Docker build to ensure corepack is available
 - Documented Node.js requirement in README

--- a/lib/download_vic_suburbs.rb
+++ b/lib/download_vic_suburbs.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Tasks
+  # Downloads the Victorian locality shapefile dataset from data.gov.au.
+  class DownloadVicSuburbs
+    DEFAULT_URL = 'https://data.gov.au/data/dataset/vic-localities/resource/latest/download/MAY25_-_VIC_-_Localities_-_Esri_Shapefiles_-_GDA94.zip'
+    DEFAULT_DIR = File.expand_path('../data/suburbs', __dir__)
+    DEFAULT_FILENAME = 'vic_suburbs.zip'
+
+    def initialize(url: DEFAULT_URL, dir: DEFAULT_DIR, filename: DEFAULT_FILENAME)
+      @url = url || DEFAULT_URL
+      @dir = dir || DEFAULT_DIR
+      @filename = filename || DEFAULT_FILENAME
+    end
+
+    def run
+      require 'fileutils'
+      require 'open-uri'
+
+      FileUtils.mkdir_p(@dir)
+      filepath = File.join(@dir, @filename)
+      URI.open(@url) do |remote|
+        File.open(filepath, 'wb') { |f| f.write(remote.read) }
+      end
+    end
+  end
+end

--- a/lib/tasks/download_vic_suburbs.rake
+++ b/lib/tasks/download_vic_suburbs.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require_relative '../download_vic_suburbs'
+
+namespace :db do
+  desc 'Download Victorian suburb shapefile dataset from data.gov.au'
+  task :download_vic_suburbs, %i[url dir filename] => :environment do |_, args|
+    Tasks::DownloadVicSuburbs.new(
+      url: args[:url],
+      dir: args[:dir],
+      filename: args[:filename]
+    ).run
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -44,25 +44,29 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```bash
    bundle exec rake db:download_trees
    ```
-8. Import the downloaded tree data (clears existing trees):
+8. Download the Victorian suburbs dataset:
+   ```bash
+   bundle exec rake db:download_vic_suburbs
+   ```
+9. Import the downloaded tree data (clears existing trees):
    ```bash
    bundle exec rake db:import_trees
    ```
    The prompts and models used when naming trees are configured in `config/llm.yml`.
-9. Name the trees:
+10. Name the trees:
    ```bash
    bundle exec rake db:name_trees
    ```
-10. Add tree relationships:
+11. Add tree relationships:
    ```bash
    bundle exec rake db:add_relationships
    ```
-11. Generate system prompts:
+12. Generate system prompts:
    ```bash
    bundle exec rake db:system_prompts
    ```
    This task now calls the configured LLM to craft a unique personality prompt for each tree based on its name and relationships.
-12. Run the test suite:
+13. Run the test suite:
    ```bash
    ruby test/run_tests.rb
    ```
@@ -72,12 +76,12 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    bundle exec brakeman -q
    ```
 
-13. Build css:
+14. Build css:
    ```bash
    yarn build:css
    ```
 
-14. Start the Rails server:
+15. Start the Rails server:
    ```bash
    ./bin/dev
    ```
@@ -157,6 +161,7 @@ must configure this value manually.
 [x] system prompt generation validates structure and retries until valid
 [x] update or add system prompt llm rating check
 [x] update system prompt generation to align with rating guidance
+[x] add rake task to download Victorian suburb shapefiles from data.gov.au
 [ ] create a database table for storing bounding boxes for melbourne suburbs and populate the table with data from ...
 [ ] when naming trees we should use lat/long data to lookup suburb and relative location in it. also save those details to the db for later use
 [ ] when naming trees we should use lat/long data to lookup nearby landmarks. also save those details to the db for later use

--- a/test/tasks/download_vic_suburbs_task_test.rb
+++ b/test/tasks/download_vic_suburbs_task_test.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'rake'
+require 'minitest/autorun'
+require 'tmpdir'
+require 'stringio'
+
+class DownloadVicSuburbsTaskTest < Minitest::Test
+  def setup
+    Rake.application = Rake::Application.new
+    Rake::Task.define_task(:environment)
+    load File.expand_path('../../lib/tasks/download_vic_suburbs.rake', __dir__)
+
+    require 'open-uri'
+    method_ref = method(:stub_open)
+    URI.singleton_class.class_eval do
+      alias_method :orig_open, :open
+      define_method(:open) do |url, *args, &blk|
+        if url == 'http://example.com/vic.zip'
+          io = method_ref.call
+          if blk
+            begin
+              blk.call(io)
+            ensure
+              io.close if io.respond_to?(:close)
+            end
+          else
+            io
+          end
+        else
+          orig_open(url, *args, &blk)
+        end
+      end
+    end
+  end
+
+  def teardown
+    URI.singleton_class.class_eval do
+      remove_method :open
+      alias_method :open, :orig_open
+      remove_method :orig_open
+    end
+  end
+
+  def stub_open
+    StringIO.new('zipdata')
+  end
+
+  def test_downloads_zip_file
+    Dir.mktmpdir do |dir|
+      Rake.application['db:download_vic_suburbs'].invoke('http://example.com/vic.zip', dir, 'vic.zip')
+      file = File.join(dir, 'vic.zip')
+      assert File.exist?(file)
+      assert_equal 'zipdata', File.read(file)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add rake task `db:download_vic_suburbs` for Victorian locality shapefiles
- document the new dataset download in setup steps
- record the task in the todo list and changelog
- test new rake task

## Testing
- `bundle exec ruby test/run_tests.rb`