### PR TITLE
[FEATURE] add suburbs table with optional spatial support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-13
+- Added `Suburb` model and migration for storing suburb boundaries
+- Application attempts to load `mod_spatialite` when available
+- Documented optional SpatiaLite setup steps in README
+
 ## 2025-06-12
 - Raised RuboCop metric limits and cleaned up tests to remove inline disables
 - Simplified CI workflow to rely on `test/run_tests.rb` for security and linting reports

--- a/app/models/suburb.rb
+++ b/app/models/suburb.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Suburb < ApplicationRecord
+end

--- a/config/initializers/spatialite.rb
+++ b/config/initializers/spatialite.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Rails.application.config.after_initialize do
+  adapter = ActiveRecord::Base.connection.adapter_name.downcase
+  next unless adapter.include?('sqlite')
+
+  begin
+    ActiveRecord::Base.connection.execute("SELECT load_extension('mod_spatialite')")
+  rescue ActiveRecord::StatementInvalid => e
+    Rails.logger.warn("Could not load SpatiaLite extension: #{e.message}")
+  end
+end

--- a/db/migrate/20250613000000_create_suburbs.rb
+++ b/db/migrate/20250613000000_create_suburbs.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+# Adds a suburbs table with optional geometry support via SpatiaLite.
+class CreateSuburbs < ActiveRecord::Migration[7.1]
+  def up
+    create_table :suburbs do |t|
+      t.string :name
+    end
+
+    begin
+      execute "SELECT load_extension('mod_spatialite');"
+      execute 'SELECT InitSpatialMetaData();'
+      execute "SELECT AddGeometryColumn('suburbs', 'boundary', 4326, 'POLYGON', 2);"
+      execute "SELECT CreateSpatialIndex('suburbs', 'boundary');"
+    rescue ActiveRecord::StatementInvalid => e
+      Rails.logger.warn("SpatiaLite not available: #{e.message}")
+      add_column :suburbs, :boundary, :text
+    end
+  end
+
+  def down
+    drop_table :suburbs
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -33,9 +33,11 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```
 5. Create and migrate the database:
    ```bash
-   bundle exec rails db:create
-   bundle exec rails db:migrate
-   ```
+  bundle exec rails db:create
+  bundle exec rails db:migrate
+  ```
+   The application attempts to load the `mod_spatialite` extension when Rails
+   connects to SQLite. Install the library if you want spatial queries to work.
 6. Seed initial users:
    ```bash
    bundle exec rails db:seed
@@ -162,7 +164,8 @@ must configure this value manually.
 [x] update or add system prompt llm rating check
 [x] update system prompt generation to align with rating guidance
 [x] add rake task to download Victorian suburb shapefiles from data.gov.au
-[ ] create a database table for storing bounding boxes for melbourne suburbs and populate the table with data from ...
+[x] create a suburbs table with a geometry boundary column using SpatiaLite
+[ ] populate the suburbs table with data from the downloaded shapefiles
 [ ] when naming trees we should use lat/long data to lookup suburb and relative location in it. also save those details to the db for later use
 [ ] when naming trees we should use lat/long data to lookup nearby landmarks. also save those details to the db for later use
 [ ] when naming trees we should use lat/long data to lookup nearby streets. also save those details to the db for later use


### PR DESCRIPTION
## Summary
- add initializer to attempt loading SpatiaLite extension
- revert database adapter to sqlite3
- add Suburb model and migration with optional geometry
- document optional SpatiaLite setup in README and TODO list
- note new migration in changelog

## Testing
- `ruby test/run_tests.rb`
  - ✅ `60 runs, 165 assertions, 0 failures, 0 errors, 0 skips`
- `bundle exec rubocop`
  - ✅ `74 files inspected, no offenses detected`
- `bundle exec brakeman -q`
  - ✅ `No warnings found`
- `bundle exec bundler-audit check --update`
  - ❌ `failed to update ruby-advisory-db`

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.