### PR TITLE
DOCS fix bundler warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-16
+- Documented how to fix ambiguous `stringio` gem warnings during `bundle install`
+
 ## 2025-06-14
 - Added rake task to import Victorian suburb shapefile data
 - Added `rgeo` and `rgeo-shapefile` gems

--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,11 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```bash
    bundle install
    ```
+   If bundler warns that `stringio` has multiple versions installed, run:
+   ```bash
+   gem cleanup stringio
+   ```
+   Then rerun `bundle install`.
 2. Install GEOS (required for suburb shapefile import):
    ```bash
    sudo apt-get install -y libgeos-dev


### PR DESCRIPTION
## Summary
- document how to clean up duplicate stringio gem

## Testing
- `ruby test/run_tests.rb`