### PR TITLE
[FIX] truncate CI report comments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,15 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('rubocop_report.txt','utf8');
-            const body = `**RuboCop Report**\n\n\`\`\`\n${report}\n\`\`\``;
+            const report = fs.readFileSync('rubocop_report.txt', 'utf8');
+            const header = '**RuboCop Report**\n\n```\n';
+            const footer = '\n```';
+            const limit = 65000;
+            let body = `${header}${report}${footer}`;
+            if (body.length > limit) {
+              const maxReport = limit - header.length - footer.length - 20;
+              body = `${header}${report.slice(0, maxReport)}\n...truncated...${footer}`;
+            }
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -64,8 +71,15 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('bundler_audit_report.txt','utf8');
-            const body = `**bundler-audit Report**\n\n\`\`\`\n${report}\n\`\`\``;
+            const report = fs.readFileSync('bundler_audit_report.txt', 'utf8');
+            const header = '**bundler-audit Report**\n\n```\n';
+            const footer = '\n```';
+            const limit = 65000;
+            let body = `${header}${report}${footer}`;
+            if (body.length > limit) {
+              const maxReport = limit - header.length - footer.length - 20;
+              body = `${header}${report.slice(0, maxReport)}\n...truncated...${footer}`;
+            }
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -78,8 +92,15 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('brakeman_report.txt','utf8');
-            const body = `**Brakeman Report**\n\n\`\`\`\n${report}\n\`\`\``;
+            const report = fs.readFileSync('brakeman_report.txt', 'utf8');
+            const header = '**Brakeman Report**\n\n```\n';
+            const footer = '\n```';
+            const limit = 65000;
+            let body = `${header}${report}${footer}`;
+            if (body.length > limit) {
+              const maxReport = limit - header.length - footer.length - 20;
+              body = `${header}${report.slice(0, maxReport)}\n...truncated...${footer}`;
+            }
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This log summarizes notable updates based on commit history and completed TODO i
 - Documented GEOS requirement for suburb import
 - Improved suburb import task error handling
 
+## 2025-06-16
+- Truncated CI report comments when exceeding GitHub's 65k limit
+
 ## 2025-06-13
 - Added `Suburb` model and migration for storing suburb boundaries
 - Application attempts to load `mod_spatialite` when available

--- a/readme.md
+++ b/readme.md
@@ -185,3 +185,4 @@ must configure this value manually.
 [ ] custom tree images - trees have images that start as the default logo, but users with the right tags could take a selfie of the tree and update it's image
 [x] get test coverage up
 [x] address remaining RuboCop warnings
+[x] truncate CI report comments to avoid GitHub's size limit


### PR DESCRIPTION
## Summary
- truncate comments for long RuboCop, bundler-audit and Brakeman reports
- document fix in readme TODO list
- note fix in CHANGELOG

## Testing
- `ruby test/run_tests.rb`