### PR TITLE
[FIX] Trim large RuboCop report in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('rubocop_report.txt','utf8');
+            let report = fs.readFileSync('rubocop_report.txt','utf8');
+            const maxLength = 65000;
+            if (report.length > maxLength) {
+              report = report.slice(0, maxLength) + '\n...truncated...';
+            }
             const body = `**RuboCop Report**\n\n\`\`\`\n${report}\n\`\`\``;
             github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-16
+- Truncated long RuboCop report in CI comments to avoid exceeding GitHub limits
+
 ## 2025-06-14
 - Added rake task to import Victorian suburb shapefile data
 - Added `rgeo` and `rgeo-shapefile` gems


### PR DESCRIPTION
## Summary
- truncate RuboCop report when commenting on PRs
- update changelog

## Testing
- `bundle install --local`
- `ruby test/run_tests.rb`
