### PR TITLE
[FIX] isolate rubocop config in tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,11 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = fs.readFileSync('rubocop_report.txt','utf8');
+            let report = fs.readFileSync('rubocop_report.txt','utf8');
+            const maxLength = 65000;
+            if (report.length > maxLength) {
+              report = report.slice(0, maxLength) + '\n...truncated...';
+            }
             const body = `**RuboCop Report**\n\n\`\`\`\n${report}\n\`\`\``;
             github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-16
+- Truncated long RuboCop report in CI comments to avoid exceeding GitHub limits
+
+## 2025-06-17
+- Force RuboCop to ignore any global configs during test runs
+
 ## 2025-06-14
 - Added rake task to import Victorian suburb shapefile data
 - Added `rgeo` and `rgeo-shapefile` gems

--- a/test/run_tests.rb
+++ b/test/run_tests.rb
@@ -27,7 +27,7 @@ Minitest.after_run do
     f.puts "TOTAL: #{total_percent}% (#{total_covered}/#{total_lines})"
   end
 
-  rubocop_output = `bundle exec rubocop 2>&1`
+  rubocop_output = `bundle exec rubocop --force-default-config --config .rubocop.yml 2>&1`
   File.write('rubocop_report.txt', rubocop_output)
 
   bundler_audit_output = `bundle exec bundler-audit check 2>&1`


### PR DESCRIPTION
## Summary
- force RuboCop to ignore global configs during test runs
- document the change in the changelog

## Testing
- `bundle install --local`
- `ruby test/run_tests.rb`
