### PR TITLE
[FIX] disable proxies only for apt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-18
+- Disabled proxies specifically for apt commands in Docker build to fix package installation
+
 ## 2025-06-16
 - Truncated long RuboCop report in CI comments to avoid exceeding GitHub limits
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM ollama/ollama:0.6.6
 # avoid interactive tzdata prompts, set proper zone
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Australia/Melbourne
-
+# disable proxies for apt commands to avoid installation errors
 USER root
-RUN apt-get update -qq && \
+RUN http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= \
+    apt-get update -qq && \
     apt-get install -y --no-install-recommends \
       build-essential \
       libssl-dev \

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,8 @@ Deployed to Koyeb: https://visiting-raynell-puzzleduck-f206ac43.koyeb.app/
 When deploying or running in production, ensure the `SECRET_KEY_BASE` environment
 variable is set. The provided Dockerfile sets a default, but other environments
 must configure this value manually.
+The Dockerfile disables any configured HTTP proxy for `apt` commands during the
+build to avoid installation issues.
 
 ## Todos
 [x] add tailwind and style tree list page


### PR DESCRIPTION
## Summary
- disable proxies only for apt commands in Dockerfile
- document the scoped proxy change in README
- log the fix in CHANGELOG

## Testing
- `ruby test/run_tests.rb`
- `tail -n 20 rubocop_report.txt`
- `tail -n 20 bundler_audit_report.txt`
- `tail -n 20 brakeman_report.txt`
