### PR TITLE
[FIX] scope proxy vars for apt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-18
+- Scoped proxy disabling to `apt` commands in Docker build to fix package installation issues
+
 ## 2025-06-16
 - Truncated long RuboCop report in CI comments to avoid exceeding GitHub limits
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,10 @@ FROM ollama/ollama:0.6.6
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Australia/Melbourne
 
+# disable proxies just for apt commands
 USER root
-RUN apt-get update -qq && \
+RUN http_proxy= https_proxy= HTTP_PROXY= HTTPS_PROXY= \
+    apt-get update -qq && \
     apt-get install -y --no-install-recommends \
       build-essential \
       libssl-dev \

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,7 @@ Deployed to Koyeb: https://visiting-raynell-puzzleduck-f206ac43.koyeb.app/
 When deploying or running in production, ensure the `SECRET_KEY_BASE` environment
 variable is set. The provided Dockerfile sets a default, but other environments
 must configure this value manually.
+The Dockerfile clears HTTP proxy variables only for the `apt` commands during build to avoid package installation failures.
 
 ## Todos
 [x] add tailwind and style tree list page
@@ -184,4 +185,5 @@ must configure this value manually.
 [ ] new tree mission: find all the ... trees named bob, trees of a species, trees on x road, trees in x park, ... (must be less than 6 in db)
 [ ] custom tree images - trees have images that start as the default logo, but users with the right tags could take a selfie of the tree and update it's image
 [x] get test coverage up
+[ ] fix remaining RuboCop warnings
 [x] address remaining RuboCop warnings


### PR DESCRIPTION
## Summary
- handle proxy vars only for apt commands during Docker build
- document apt proxy handling change in README
- log fix in changelog
- add todo item about fixing rubocop warnings

## Testing
- `ruby test/run_tests.rb`
- `tail -n 20 rubocop_report.txt`
- `tail -n 20 bundler_audit_report.txt`
- `tail -n 20 brakeman_report.txt`
