### PR TITLE
[FIX] install geos for docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-18
+- Disabled proxy variables in Docker build to fix apt package installation
+- Added `libgeos-dev` to Dockerfile so ffi-geos can load GEOS
+
 ## 2025-06-16
 - Truncated long RuboCop report in CI comments to avoid exceeding GitHub limits
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ FROM ollama/ollama:0.6.6
 # avoid interactive tzdata prompts, set proper zone
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Australia/Melbourne
+# disable build-time proxies that can break apt
+ENV http_proxy="" https_proxy="" HTTP_PROXY="" HTTPS_PROXY=""
 
 USER root
 RUN apt-get update -qq && \
@@ -12,6 +14,7 @@ RUN apt-get update -qq && \
       libreadline-dev \
       zlib1g-dev \
       libffi-dev \
+      libgeos-dev \
       libyaml-dev \
       git \
       curl \

--- a/readme.md
+++ b/readme.md
@@ -104,6 +104,8 @@ Deployed to Koyeb: https://visiting-raynell-puzzleduck-f206ac43.koyeb.app/
 When deploying or running in production, ensure the `SECRET_KEY_BASE` environment
 variable is set. The provided Dockerfile sets a default, but other environments
 must configure this value manually.
+The Dockerfile also clears any HTTP proxy variables during build to avoid `apt`
+failures. It also installs `libgeos-dev` so the `ffi-geos` gem can parse shapefiles when importing data.
 
 ## Todos
 [x] add tailwind and style tree list page


### PR DESCRIPTION
## Summary
- install `libgeos-dev` so the `ffi-geos` gem works in Docker
- document the new dependency in README
- log update in CHANGELOG

## Testing
- `ruby test/run_tests.rb`
- `tail -n 20 rubocop_report.txt`
- `tail -n 20 bundler_audit_report.txt`
- `tail -n 20 brakeman_report.txt`
