### PR TITLE
[FIX] resolve remaining rubocop warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This log summarizes notable updates based on commit history and completed TODO i
 ## 2025-06-17
 - Force RuboCop to ignore any global configs during test runs
 
+## 2025-06-18
+- Fixed remaining RuboCop warnings
+
 ## 2025-06-14
 - Added rake task to import Victorian suburb shapefile data
 - Added `rgeo` and `rgeo-shapefile` gems

--- a/test/tasks/import_suburbs_task_test.rb
+++ b/test/tasks/import_suburbs_task_test.rb
@@ -3,17 +3,19 @@
 require_relative '../test_helper'
 require 'rake'
 require 'minitest/autorun'
-require 'ostruct'
+
+SuburbRecord = Struct.new(:attributes, :geometry)
 
 class ImportSuburbsTaskTest < Minitest::Test
   RECORDS = [
-    OpenStruct.new(attributes: { 'NAME' => 'Alpha' }, geometry: :poly1),
-    OpenStruct.new(attributes: { 'LOCALITY' => 'Beta' }, geometry: :poly2)
-  ]
+    SuburbRecord.new({ 'NAME' => 'Alpha' }, :poly1),
+    SuburbRecord.new({ 'LOCALITY' => 'Beta' }, :poly2)
+  ].freeze
 
   def setup
     Suburb.singleton_class.class_eval do
       attr_accessor :records
+
       def delete_all = self.records = []
       def create!(attrs) = (self.records ||= []) << attrs
     end
@@ -23,6 +25,7 @@ class ImportSuburbsTaskTest < Minitest::Test
       alias_method :orig_require, :require
       def require(name)
         return true if name == 'rgeo/shapefile'
+
         orig_require(name)
       end
     end


### PR DESCRIPTION
## Summary
- remove use of OpenStruct in suburb task test
- document rubocop warning cleanup

## Testing
- `ruby test/run_tests.rb`
- `bundle exec rubocop`