### PR TITLE
[FIX] address rubocop offense

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This log summarizes notable updates based on commit history and completed TODO i
 ## 2025-05-29
 - Refactored `TreesController` to reduce RuboCop offenses
 - Removed temporary rubocop directives from controller and test helper
+- Fixed presenter require quoting style for RuboCop
 
 ## 2025-06-14
 - Added rake task to import Victorian suburb shapefile data

--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "../presenters/tree_presenter"
+require_relative '../presenters/tree_presenter'
 # Provides endpoints for listing and interacting with trees.
 class TreesController < ApplicationController
   def index


### PR DESCRIPTION
## Summary
- fix RuboCop warning about double quotes in `TreesController`
- note the change in CHANGELOG

## Testing
- `ruby test/run_tests.rb`
- `bundle exec rubocop`
