### PR TITLE
[FIX] brighten suburb boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This log summarizes notable updates based on commit history and completed TODO items.
 
+## 2025-06-19
+- Added API endpoint and frontend support to display suburb boundaries on the map
+- Made suburb boundaries bright green on the map
+
 ## 2025-06-16
 - Truncated long RuboCop report in CI comments to avoid exceeding GitHub limits
 

--- a/app/controllers/suburbs_controller.rb
+++ b/app/controllers/suburbs_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Provides suburb boundary data for the map.
+class SuburbsController < ApplicationController
+  def index
+    data = Suburb.all.map { |s| { name: s.name, polygons: s.polygons } }
+    render json: data
+  end
+end

--- a/app/models/suburb.rb
+++ b/app/models/suburb.rb
@@ -1,4 +1,35 @@
 # frozen_string_literal: true
 
+# Represents a suburb boundary polygon.
+require 'rgeo'
 class Suburb < ApplicationRecord
+  # Returns an array of polygons representing the suburb boundary.
+  # Each polygon is an array of [lat, lon] coordinate pairs.
+  def polygons
+    require 'rgeo' unless defined?(::RGeo)
+
+    geom = boundary
+    unless geom.respond_to?(:geometry_type)
+      factory = ::RGeo::Geographic.spherical_factory(srid: 4326)
+      begin
+        geom = ::RGeo::WKRep::WKTParser.new(factory, support_ewkt: true).parse(boundary.to_s)
+      rescue ::RGeo::Error::ParseError
+        return []
+      end
+    end
+
+    if geom.geometry_type == ::RGeo::Feature::MultiPolygon
+      geom.map { |poly| ring_coords(poly.exterior_ring) }
+    elsif geom.geometry_type == ::RGeo::Feature::Polygon
+      [ring_coords(geom.exterior_ring)]
+    else
+      []
+    end
+  end
+
+  private
+
+  def ring_coords(ring)
+    ring.points.map { |p| [p.y, p.x] }
+  end
 end

--- a/app/views/trees/index.html.erb
+++ b/app/views/trees/index.html.erb
@@ -166,6 +166,17 @@
       }
     }
 
+    var suburbLayers = [];
+    fetch('/suburbs.json').then(function(resp){ return resp.json(); }).then(function(data){
+      data.forEach(function(sub){
+        (sub.polygons || []).forEach(function(poly){
+          suburbLayers.push(
+            L.polygon(poly, {color: '#00ff00', weight: 1, fillOpacity: 0.05}).addTo(map)
+          );
+        });
+      });
+    });
+
     function distanceMeters(lat1, lon1, lat2, lon2) {
       var rad = Math.PI / 180;
       var dLat = (lat2 - lat1) * rad;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,5 @@ Rails.application.routes.draw do
   post 'select_user', to: 'application#select_user'
   post 'update_location', to: 'application#update_location'
   post 'know_tree/:id', to: 'application#know_tree'
+  resources :suburbs, only: [:index]
 end

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ https://github.com/gbaptista/ollama-ai?tab=readme-ov-file#chat-generate-a-chat-c
    ```bash
    bundle exec rake db:import_suburbs
    ```
+   Suburb boundaries will appear in bright green on the map when this dataset is loaded.
 10. Import the downloaded tree data (clears existing trees):
    ```bash
    bundle exec rake db:import_trees

--- a/test/controllers/suburbs_controller_test.rb
+++ b/test/controllers/suburbs_controller_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'minitest/autorun'
+require_relative '../../app/controllers/suburbs_controller'
+
+class SuburbsControllerTest < Minitest::Test
+  def setup
+    require 'rgeo'
+    Suburb.singleton_class.class_eval do
+      attr_accessor :records
+
+      def all = records
+    end
+  end
+
+  def teardown
+    Suburb.records = nil
+  end
+
+  def test_index_returns_suburb_polygons
+    Suburb.records = [
+      Suburb.new(name: 'Alpha', boundary: 'POLYGON((0 0,1 0,1 1,0 1,0 0))'),
+      Suburb.new(name: 'Beta', boundary: 'POLYGON((2 2,3 2,3 3,2 3,2 2))')
+    ]
+
+    controller = SuburbsController.new
+    controller.index
+
+    expected = [
+      {
+        name: 'Alpha',
+        polygons: [[
+          [0.0, 0.0],
+          [0.0, 1.0],
+          [1.0, 1.0],
+          [1.0, 0.0],
+          [0.0, 0.0]
+        ]]
+      },
+      {
+        name: 'Beta',
+        polygons: [[
+          [2.0, 2.0],
+          [2.0, 3.0],
+          [3.0, 3.0],
+          [3.0, 2.0],
+          [2.0, 2.0]
+        ]]
+      }
+    ]
+    assert_equal expected, controller.rendered
+  end
+end

--- a/test/models/suburb_test.rb
+++ b/test/models/suburb_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'minitest/autorun'
+require 'rgeo'
+
+class SuburbTest < Minitest::Test
+  def test_polygons_parses_wkt
+    s = Suburb.new(boundary: 'POLYGON((0 0,1 0,1 1,0 1,0 0))')
+    expected = [[
+      [0.0, 0.0],
+      [0.0, 1.0],
+      [1.0, 1.0],
+      [1.0, 0.0],
+      [0.0, 0.0]
+    ]]
+    assert_equal expected, s.polygons
+  end
+end


### PR DESCRIPTION
## Summary
- refine Suburb#polygons to reload RGeo when missing
- show suburb polygons in bright green on the map
- document bright green boundaries

## Testing
- `ruby test/run_tests.rb`