### PR TITLE
don't allow comma in names

### DIFF
--- a/lib/tree_namer.rb
+++ b/lib/tree_namer.rb
@@ -115,7 +115,7 @@ module Tasks
     private_constant :BANNED_WORDS_REGEX
 
     def valid_format?(name, tree, reasons)
-      if name =~ /[^\w\s,-]/
+      if name =~ /[^\w\s-]/
         puts "Rejected name due to punctuation: #{name.inspect}"
         reasons << 'invalid punctuation'
         false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for tree names to prevent the use of commas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->